### PR TITLE
Add Claude Desktop .mcpb extension support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,11 @@ jobs:
           shasum -a 256 pdf-analyzer-* > checksums.txt
           cat checksums.txt
 
+      - name: Build .mcpb desktop extension
+        run: |
+          chmod +x scripts/build-mcpb.sh
+          RELEASE_DIR=$PWD/bin OUTPUT_DIR=$PWD/bin scripts/build-mcpb.sh ${GITHUB_REF#refs/tags/v}
+
       - name: Get version from tag
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
@@ -160,6 +165,7 @@ jobs:
             bin/pdf-analyzer-linux-x64
             bin/pdf-analyzer-windows-x64.exe
             bin/checksums.txt
+            bin/pdf-analyzer.mcpb
           draft: false
           prerelease: false
         env:

--- a/README.md
+++ b/README.md
@@ -74,134 +74,63 @@ The server automatically loads the API key from `.env` in your current working d
 
 ## Connect the MCP with your favorite AI tool
 
+After installing the MCP with one of the methods above, you can connect it to your AI agent of choice.
+
 ### Claude Desktop
 
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
-or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+1. Download the [Claude Desktop app](https://claude.ai/download)
+2. Open Claude Desktop and go to **Settings** (gear icon)
+3. Under **Desktop app**, click **Extensions**
+4. Click **Advanced settings**
+5. In the **Extension Developer** section, click **Install Extension...**
+6. Navigate to your install directory and select `pdf-analyzer.mcpb`:
+   - **macOS**: `~/Library/Application Support/pdf-analyzer/pdf-analyzer.mcpb`
+   - **Windows**: `%LOCALAPPDATA%\pdf-analyzer\pdf-analyzer.mcpb`
+
+The extension will be available immediately in your conversations.
+
+### Claude Code
+
+Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code), then run:
+
+```bash
+claude mcp add --scope user --env GEMINI_API_KEY=your-key pdf-analyzer -- pdf-analyzer
+```
+
+### OpenAI Codex
+
+Install [OpenAI Codex](https://github.com/openai/codex), then run:
+
+```bash
+codex mcp add pdf-analyzer --env GEMINI_API_KEY=your-key -- pdf-analyzer
+```
+
+### Gemini CLI
+
+Install [Gemini CLI](https://github.com/google-gemini/gemini-cli), then run:
+
+```bash
+gemini mcp add --scope user -e GEMINI_API_KEY=your-key pdf-analyzer pdf-analyzer
+```
+
+### VS Code (GitHub Copilot)
+
+Download [VS Code](https://code.visualstudio.com/)
+
+Add to `.vscode/mcp.json` in your project:
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "pdf-analyzer": {
+      "type": "stdio",
       "command": "pdf-analyzer"
     }
   }
 }
 ```
 
-<details>
-<summary><strong>Claude Code</strong></summary>
-
-```bash
-claude mcp add pdf-analyzer -- pdf-analyzer
-```
-
-Or using the standalone binary path:
-
-macOS:
-
-```bash
-claude mcp add pdf-analyzer -- ~/Library/Application\ Support/pdf-analyzer/bin/pdf-analyzer
-```
-
-Linux:
-
-```bash
-claude mcp add pdf-analyzer -- ~/.pdf-analyzer/bin/pdf-analyzer
-```
-
-</details>
-
-<details>
-<summary><strong>VS Code (GitHub Copilot)</strong></summary>
-
-Add to `.vscode/mcp.json` in your project.
-
-**macOS:**
-
-```json
-{
-  "servers": {
-    "pdf-analyzer": {
-      "type": "stdio",
-      "command": "/Users/YOUR_USERNAME/Library/Application Support/pdf-analyzer/bin/pdf-analyzer"
-    }
-  }
-}
-```
-
-**Linux:**
-
-```json
-{
-  "servers": {
-    "pdf-analyzer": {
-      "type": "stdio",
-      "command": "/home/YOUR_USERNAME/.pdf-analyzer/bin/pdf-analyzer"
-    }
-  }
-}
-```
-
-**Windows:**
-
-```json
-{
-  "servers": {
-    "pdf-analyzer": {
-      "type": "stdio",
-      "command": "C:\\Users\\YOUR_USERNAME\\AppData\\Local\\pdf-analyzer\\bin\\pdf-analyzer.exe"
-    }
-  }
-}
-```
-
-Then enable in **Configure Tools** (click the tools icon in Copilot chat).
-
-</details>
-
-<details>
-<summary><strong>Gemini CLI</strong></summary>
-
-Add to `~/.gemini/settings.json` (global) or `.gemini/settings.json` (project).
-
-**macOS:**
-
-```json
-{
-  "mcpServers": {
-    "pdf-analyzer": {
-      "command": "/Users/YOUR_USERNAME/Library/Application Support/pdf-analyzer/bin/pdf-analyzer"
-    }
-  }
-}
-```
-
-**Linux:**
-
-```json
-{
-  "mcpServers": {
-    "pdf-analyzer": {
-      "command": "/home/YOUR_USERNAME/.pdf-analyzer/bin/pdf-analyzer"
-    }
-  }
-}
-```
-
-**Windows:**
-
-```json
-{
-  "mcpServers": {
-    "pdf-analyzer": {
-      "command": "C:\\Users\\YOUR_USERNAME\\AppData\\Local\\pdf-analyzer\\bin\\pdf-analyzer.exe"
-    }
-  }
-}
-```
-
-</details>
+Then enable it in **Configure Tools** (click the tools icon in Copilot chat).
 
 ## Usage
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/mcpb/main/mcpb-manifest.schema.json",
+  "manifest_version": "0.3",
+  "name": "pdf-analyzer",
+  "display_name": "PDF Analyzer",
+  "version": "0.0.5",
+  "description": "Analyze PDF documents and answer questions about their content using AI",
+  "long_description": "The PDF Analyzer MCP Server gives AI agents the ability to read and analyze PDF documents, enabling document Q&A through natural conversations.\n\nPowered by Google's Gemini API. Supports local files and URLs.",
+  "author": {
+    "name": "IntelligentElectron",
+    "url": "https://github.com/IntelligentElectron"
+  },
+  "icon": "icon.png",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/IntelligentElectron/pdf-analyzer"
+  },
+  "homepage": "https://github.com/IntelligentElectron/pdf-analyzer",
+  "keywords": [
+    "PDF",
+    "document",
+    "analysis",
+    "Gemini",
+    "MCP",
+    "AI"
+  ],
+  "server": {
+    "type": "binary",
+    "entry_point": "server/pdf-analyzer",
+    "mcp_config": {
+      "command": "${__dirname}/server/pdf-analyzer",
+      "env": {
+        "GEMINI_API_KEY": ""
+      }
+    }
+  },
+  "compatibility": {
+    "claude_desktop": ">=1.0.0",
+    "platforms": ["darwin", "win32"]
+  },
+  "tools_generated": true,
+  "tools": [
+    {
+      "name": "analyze_pdf",
+      "description": "Analyze a PDF document using AI and answer questions about its content"
+    }
+  ]
+}

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Build .mcpb desktop extension bundle for Claude Desktop
+#
+# Usage:
+#   ./scripts/build-mcpb.sh [version]
+#
+# Expects binaries in the release/ directory:
+#   - pdf-analyzer-darwin-arm64
+#   - pdf-analyzer-darwin-x64
+#   - pdf-analyzer-windows-x64.exe
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Get version from argument or manifest.json
+VERSION="${1:-$(grep '"version"' "$PROJECT_DIR/manifest.json" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')}"
+
+echo "📦 Building pdf-analyzer.mcpb v${VERSION}"
+
+# Create temp directory for bundle
+BUNDLE_DIR=$(mktemp -d)
+trap "rm -rf '$BUNDLE_DIR'" EXIT
+
+# Create server directory
+mkdir -p "$BUNDLE_DIR/server"
+
+# Copy manifest.json and update version
+sed "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" "$PROJECT_DIR/manifest.json" > "$BUNDLE_DIR/manifest.json"
+
+# Copy binaries
+# MCPB convention: server/name for Unix, server/name.exe for Windows
+# Claude Desktop auto-selects based on platform
+
+RELEASE_DIR="${RELEASE_DIR:-$PROJECT_DIR/release}"
+
+# Select macOS binary (prefer arm64 for Apple Silicon, most common on modern Macs)
+# Can be overridden with MACOS_ARCH=x64 environment variable
+if [ "${MACOS_ARCH:-arm64}" = "x64" ]; then
+    MACOS_BINARY="pdf-analyzer-darwin-x64"
+else
+    MACOS_BINARY="pdf-analyzer-darwin-arm64"
+fi
+
+# Copy macOS binary (use arch-appropriate binary as the main one)
+if [ -f "$RELEASE_DIR/$MACOS_BINARY" ]; then
+    cp "$RELEASE_DIR/$MACOS_BINARY" "$BUNDLE_DIR/server/pdf-analyzer"
+    chmod +x "$BUNDLE_DIR/server/pdf-analyzer"
+    echo "  ✓ Added macOS binary ($MACOS_BINARY)"
+elif [ -f "$RELEASE_DIR/pdf-analyzer-darwin-arm64" ]; then
+    cp "$RELEASE_DIR/pdf-analyzer-darwin-arm64" "$BUNDLE_DIR/server/pdf-analyzer"
+    chmod +x "$BUNDLE_DIR/server/pdf-analyzer"
+    echo "  ✓ Added macOS binary (darwin-arm64)"
+elif [ -f "$RELEASE_DIR/pdf-analyzer-darwin-x64" ]; then
+    cp "$RELEASE_DIR/pdf-analyzer-darwin-x64" "$BUNDLE_DIR/server/pdf-analyzer"
+    chmod +x "$BUNDLE_DIR/server/pdf-analyzer"
+    echo "  ✓ Added macOS binary (darwin-x64)"
+fi
+
+# Copy Windows binary
+if [ -f "$RELEASE_DIR/pdf-analyzer-windows-x64.exe" ]; then
+    cp "$RELEASE_DIR/pdf-analyzer-windows-x64.exe" "$BUNDLE_DIR/server/pdf-analyzer.exe"
+    echo "  ✓ Added Windows binary"
+fi
+
+# Copy icon if exists
+if [ -f "$PROJECT_DIR/icon.png" ]; then
+    cp "$PROJECT_DIR/icon.png" "$BUNDLE_DIR/icon.png"
+    echo "  ✓ Added icon"
+fi
+
+# Create the .mcpb bundle (ZIP archive)
+OUTPUT_FILE="${OUTPUT_DIR:-$RELEASE_DIR}/pdf-analyzer.mcpb"
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+cd "$BUNDLE_DIR"
+zip -r "$OUTPUT_FILE" .
+
+echo ""
+echo "✅ Created $OUTPUT_FILE"
+echo ""
+echo "Bundle contents:"
+unzip -l "$OUTPUT_FILE"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -61,6 +61,10 @@ echo ""
 echo "Updating package.json..."
 sed -i '' "s/\"version\": \".*\"/\"version\": \"${NEW_VERSION}\"/" "package.json"
 
+# Update manifest.json (for .mcpb desktop extension)
+echo "Updating manifest.json..."
+sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"${NEW_VERSION}\"/" "manifest.json"
+
 # Run checks
 echo ""
 echo "Running checks..."
@@ -71,7 +75,7 @@ npm test
 # Stage and commit
 echo ""
 echo "Committing..."
-git add "package.json"
+git add "package.json" "manifest.json"
 git commit -m "chore: release v${NEW_VERSION}"
 
 # Push


### PR DESCRIPTION
## Summary
- Add `manifest.json` and `scripts/build-mcpb.sh` for `.mcpb` bundle packaging
- Add `.mcpb` build step to release workflow and include in release assets
- Download `.mcpb` in `install.sh` with Claude Desktop install instructions
- Update `scripts/release.sh` to bump `manifest.json` version
- Update README with extension install steps and download links for all AI tools
- Scope Claude Code and Gemini CLI install commands to user level

No source code changes — the `.mcpb` will be built on the next release that includes source changes.

## Test plan
- [ ] Verify `scripts/build-mcpb.sh` runs locally (requires binaries in `release/` dir)
- [ ] Confirm `manifest.json` is valid against schema
- [ ] Check README renders correctly on GitHub