### PR TITLE
Fix OpenAI Codex and Gemini CLI install links

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ claude mcp add --scope user --env GEMINI_API_KEY=your-key pdf-analyzer -- pdf-an
 
 ### OpenAI Codex
 
-Install [OpenAI Codex](https://github.com/openai/codex), then run:
+Install [OpenAI Codex](https://developers.openai.com/codex/cli/), then run:
 
 ```bash
 codex mcp add pdf-analyzer --env GEMINI_API_KEY=your-key -- pdf-analyzer
@@ -107,7 +107,7 @@ codex mcp add pdf-analyzer --env GEMINI_API_KEY=your-key -- pdf-analyzer
 
 ### Gemini CLI
 
-Install [Gemini CLI](https://github.com/google-gemini/gemini-cli), then run:
+Install [Gemini CLI](https://geminicli.com/docs/get-started/installation/), then run:
 
 ```bash
 gemini mcp add --scope user -e GEMINI_API_KEY=your-key pdf-analyzer pdf-analyzer


### PR DESCRIPTION
## Summary
- Update OpenAI Codex link to https://developers.openai.com/codex/cli/
- Update Gemini CLI link to https://geminicli.com/docs/get-started/installation/