### PR TITLE
Fix AI tool links and remove Claude Desktop section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,7 @@ npm update -g @intelligentelectron/pdf-analyzer
 
 1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
 2. Create a new API key (free tier available)
-3. Create a `.env` file in your project folder:
-
-```
-GEMINI_API_KEY=your-api-key-here
-```
-
-The server automatically loads the API key from `.env` in your current working directory.
+3. Copy your API key, we will use it to setup the MCP in the next section
 
 ## Connect the MCP with your favorite AI tool
 


### PR DESCRIPTION
## Summary
- Fix OpenAI Codex and Gemini CLI install links to point to correct URLs
- Remove Claude Desktop section (`.mcpb` extension doesn't properly handle `GEMINI_API_KEY` env var)
- Add `env` config and `.gitignore` warning to VS Code section