### PR TITLE
Fix claude mcp add command argument order

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ After installing the MCP with one of the methods above, you can connect it to yo
 Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code), then run:
 
 ```bash
-claude mcp add --scope user --env GEMINI_API_KEY=your-key pdf-analyzer -- pdf-analyzer
+claude mcp add --scope user pdf-analyzer --env GEMINI_API_KEY=your-key -- pdf-analyzer
 ```
 
 ### OpenAI Codex


### PR DESCRIPTION
## Summary
- Fix incorrect argument order in Claude Code setup command
- Server name must come before `--env` flag

## Test plan
- [ ] Verify command works: `claude mcp add --scope user pdf-analyzer --env GEMINI_API_KEY=test -- pdf-analyzer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)