### PR TITLE
chore: ignore .plans directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ coverage/
 # Claude
 .claude/settings.local.json
 .mcp.json
+
+# Plans
+.plans/


### PR DESCRIPTION
## Summary
- rename local plans/ workspace folder to .plans/
- update .gitignore to ignore .plans/

## Notes
- only .gitignore is tracked in this PR because plans are intentionally ignored