### PR TITLE
chore: add .envrc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ npm-debug.log*
 # Environment
 .env
 .env.local
+.envrc
 
 # Test coverage
 coverage/


### PR DESCRIPTION
## Summary
- Add `.envrc` (direnv) to `.gitignore` alongside existing `.env` and `.env.local` entries
- direnv files are user-specific environment config and should not be tracked

## Test plan
- [x] Verify `.envrc` no longer shows as untracked in `git status`