### PR TITLE
v1.0.0: Multi-provider support via Vercel AI SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,3 @@ coverage/
 # Claude
 .claude/settings.local.json
 .mcp.json
-
-# Plans
-.plans/

--- a/.plans/rate-limit-handling.md
+++ b/.plans/rate-limit-handling.md
@@ -1,0 +1,41 @@
+# Rate Limit Handling for Chunked PDFs
+
+## Problem
+
+When processing large PDFs (e.g., 980-page nRF52840 spec) with OpenAI, the chunking loop sends multiple large requests back-to-back. This exceeds the TPM (tokens per minute) rate limit:
+
+```
+Limit 500000, Used 387097, Requested 210705
+"Please try again in 11.736s"
+```
+
+The current retry logic (3 attempts) does not distinguish rate limit errors from other failures, so retries fire immediately and fail again.
+
+## Approaches
+
+### 1. Retry with backoff on rate limit errors
+
+Parse the `retry-after` value from the error response and wait that duration before retrying. The AI SDK's `generateText` accepts `maxRetries`, but the default retry strategy may not respect provider-specific cooldown periods.
+
+- Detect rate limit errors per provider (HTTP 429 or provider-specific patterns)
+- Extract the wait duration from the error message or `Retry-After` header
+- Retry after the specified delay
+- Increase `maxRetries` for rate-limited requests (e.g., 5 instead of 3)
+
+### 2. Throttle between chunks
+
+Add a configurable delay between chunk processing calls to stay under TPM limits proactively, rather than reacting to failures.
+
+- Track elapsed time between chunk calls
+- If the previous call completed quickly, add a delay before the next one
+- This prevents rate limits entirely rather than recovering from them
+
+### 3. Provider-specific notes
+
+- **Google Gemini**: Not affected. File API uploads once server-side; token throughput is not a bottleneck.
+- **Anthropic Claude**: Higher default rate limits. Less likely to hit this, but the 100-page PDF limit triggers chunking which could still cause issues at scale.
+- **OpenAI**: Most susceptible due to lower TPM limits on standard tiers. Both approaches above are relevant here.
+
+## Recommendation
+
+Combine both: add inter-chunk throttling as the primary defense, and retry-after handling as a safety net. The throttle prevents most rate limit errors; the retry handles edge cases where the estimate is off.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.0] - 2026-03-22
+
+### Added
+- Multi-provider support: Google Gemini, Anthropic Claude, and OpenAI
+- Interactive TUI setup (`--setup`) with provider and model selection using @clack/prompts
+- Model selection per provider: fast (cost-effective) and flagship options
+  - Google: Gemini 3 Flash / Gemini 3.1 Pro
+  - Anthropic: Claude Sonnet 4.6 / Claude Opus 4.6
+  - OpenAI: GPT-5.4 Mini / GPT-5.4
+- Provider-specific PDF handling: Gemini File API for Google, inline bytes for Anthropic and OpenAI
+- Thinking/reasoning set to minimum across all providers (optimized for document analysis)
+
+### Changed
+- Migrated from direct `@google/genai` SDK to Vercel AI SDK V6 for provider abstraction
+- Replaced Gemini-specific `Type.OBJECT` schemas with Zod schemas (`Output.object()`)
+- Generalized keychain storage to support provider ID, model ID, and API key
+- Adaptive chunking now works across all providers (not just Gemini)
+- Response includes `model` field showing which model produced the response
+- `--set-key` is now a deprecated alias for `--setup`
+
+### Removed
+- Legacy `GEMINI_API_KEY` credential and backward-compatibility fallback
+- Direct dependency on `@google/genai` for LLM calls (kept for File API uploads only)
+
 ## [0.2.0] - 2026-03-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,17 +18,24 @@ git checkout <branch-name>        # Switch to your branch
 git push -u origin <branch-name>  # Push and create PR
 ```
 
-## CRITICAL: Gemini Model
+## CRITICAL: Model Configuration
 
-**ALWAYS use `gemini-3.1-pro-preview` as the model. NEVER change it to any other model (e.g., gemini-2.5-pro-preview, gemini-2.0-flash, etc.).**
+Models per provider (do not change without discussion). Users choose during `--setup`:
 
+- **Google Gemini**: `gemini-3-flash-preview` (fast) / `gemini-3.1-pro-preview` (flagship)
+- **Anthropic Claude**: `claude-sonnet-4-6` (fast) / `claude-opus-4-6` (flagship)
+- **OpenAI**: `gpt-5.4-mini` (fast) / `gpt-5.4` (flagship)
+
+Thinking/reasoning is set to minimum for all models (document analysis doesn't benefit from extended thinking).
+
+References (Google File API for large PDFs):
 - <https://ai.google.dev/gemini-api/docs/document-processing>
-- <https://ai.google.dev/gemini-api/docs/document-processing#large-pdfs> (File API for large PDFs)
-- <https://ai.google.dev/gemini-api/docs/files> (Files API reference)
+- <https://ai.google.dev/gemini-api/docs/document-processing#large-pdfs>
+- <https://ai.google.dev/gemini-api/docs/files>
 
 ## Overview
 
-Standalone MCP server for analyzing PDF documents using Gemini API. Distributed as self-updating binaries for all platforms. Users provide their own Gemini API key.
+Standalone MCP server for analyzing PDF documents using AI. Supports multiple LLM providers (Google Gemini, Anthropic Claude, OpenAI) via the Vercel AI SDK. Distributed as self-updating binaries for all platforms. Users choose their provider and provide an API key during setup.
 
 ## Build & Package
 
@@ -128,9 +135,9 @@ xcrun notarytool submit pdf-analyzer-darwin-arm64.zip \
 xcrun stapler staple pdf-analyzer-darwin-arm64
 ```
 
-## API Key Storage
+## Credential Storage
 
-The Gemini API key is stored in the OS credential store (macOS Keychain, Linux `secret-tool`, Windows Credential Manager). Users set it via `pdf-analyzer --set-key` or during installation.
+The provider ID and API key are stored in the OS credential store (macOS Keychain, Linux `secret-tool`, Windows Credential Manager). Users set them via `pdf-analyzer --setup` or during installation. Backward compatible with the legacy `GEMINI_API_KEY` credential.
 
 ## CLI Commands
 
@@ -138,6 +145,8 @@ The Gemini API key is stored in the OS credential store (macOS Keychain, Linux `
 pdf-analyzer              # Run server (with auto-update check)
 pdf-analyzer --version    # Print version
 pdf-analyzer --help       # Show help
+pdf-analyzer --setup      # Choose provider and store API key
+pdf-analyzer --set-key    # Deprecated alias for --setup
 pdf-analyzer --update     # Manual update check
 pdf-analyzer --uninstall  # Remove binary and PATH entries
 ```
@@ -156,7 +165,7 @@ Release marked as `prerelease: true`. GitHub `/releases/latest` ignores prerelea
 ### MCP not connecting
 - Check PATH: `which pdf-analyzer`
 - Restart terminal after install
-- Verify GEMINI_API_KEY is stored: `pdf-analyzer --set-key`
+- Verify provider is configured: `pdf-analyzer --setup`
 
 ### npm OIDC Publishing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@intelligentelectron/pdf-analyzer",
-  "version": "0.2.0",
-  "description": "MCP server for analyzing PDF documents using Gemini API",
+  "version": "1.0.0",
+  "description": "MCP server for analyzing PDF documents using AI (Google Gemini, Anthropic Claude, OpenAI)",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -44,8 +44,13 @@
     "compile:windows-x64": "bun build --compile --minify --target=bun-windows-x64 --define BUILD_VERSION=\"\\\"$(node -p 'require(\\\"./package.json\\\").version')\\\"\" src/index.ts --outfile=bin/pdf-analyzer-windows-x64.exe"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.63",
+    "@ai-sdk/google": "^3.0.52",
+    "@ai-sdk/openai": "^3.0.47",
+    "@clack/prompts": "^1.1.0",
     "@google/genai": "^1.37.0",
     "@modelcontextprotocol/sdk": "^1.25.2",
+    "ai": "^6.0.134",
     "pdf-lib": "^1.17.1",
     "zod": "^4.1.12"
   },
@@ -71,8 +76,11 @@
   "keywords": [
     "mcp",
     "pdf",
-    "gemini",
     "ai",
-    "document-analysis"
+    "document-analysis",
+    "gemini",
+    "claude",
+    "openai",
+    "multi-provider"
   ]
 }

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,14 +1,24 @@
 /**
- * CLI command handlers for --version, --help, --update, --set-key, and --uninstall.
+ * CLI command handlers for --version, --help, --setup, --update, and --uninstall.
  */
 
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import * as clack from "@clack/prompts";
 import { VERSION, GITHUB_REPO, BINARY_NAME } from "../version.js";
 import { checkForUpdate, performUpdate } from "./updater.js";
 import { removeFromPath } from "./shell.js";
-import { getStoredApiKey, setStoredApiKey, deleteStoredApiKey } from "../keychain.js";
+import {
+  getApiKey,
+  setApiKey,
+  getActiveProvider,
+  setActiveProvider,
+  getModel,
+  setModel,
+  deleteAllCredentials,
+} from "../keychain.js";
+import { providerList } from "../providers/registry.js";
 
 /**
  * Print version information.
@@ -25,22 +35,25 @@ export const printHelp = (): void => {
     `
 ${BINARY_NAME} v${VERSION}
 
-MCP server for analyzing PDF documents using Gemini AI.
+MCP server for analyzing PDF documents using AI.
+Supports Google Gemini, Anthropic Claude, and OpenAI.
 
 USAGE:
   ${BINARY_NAME} [OPTIONS]
 
 OPTIONS:
   --version, -v    Print version and exit
-  --set-key        Store your Gemini API key in the OS credential store
+  --setup          Choose an LLM provider and store your API key
+  --set-key        Alias for --setup (deprecated)
   --update         Check for updates and apply if available
   --uninstall      Remove ${BINARY_NAME} from the system
   --help, -h       Show this help message
 
-API KEY SETUP:
-  ${BINARY_NAME} --set-key
+PROVIDER SETUP:
+  ${BINARY_NAME} --setup
 
-  Stores your Gemini API key in the OS credential store (macOS Keychain,
+  Lets you choose a provider (Google Gemini, Anthropic Claude, or OpenAI)
+  and stores your API key in the OS credential store (macOS Keychain,
   Windows Credential Manager, or Linux secret-tool).
 
 INSTALLATION:
@@ -62,118 +75,93 @@ MORE INFO:
 };
 
 /**
- * Simple confirmation prompt for terminal.
+ * Check if a clack prompt was cancelled (Ctrl+C).
  */
-const confirm = async (message: string): Promise<boolean> => {
-  return new Promise((resolve) => {
-    process.stdout.write(`${message} [y/N] `);
-
-    const onData = (data: Buffer) => {
-      const answer = data.toString().trim().toLowerCase();
-      process.stdin.removeListener("data", onData);
-      process.stdin.pause();
-      resolve(answer === "y" || answer === "yes");
-    };
-
-    process.stdin.resume();
-    process.stdin.setEncoding("utf8");
-    process.stdin.once("data", onData);
-  });
-};
+function assertNotCancelled<T>(value: T | symbol): asserts value is T {
+  if (clack.isCancel(value)) {
+    clack.cancel("Setup cancelled.");
+    process.exit(0);
+  }
+}
 
 /**
- * Read a line from the terminal with masked input (each character shown as *).
+ * Handle the --setup flag: choose provider and store API key.
  */
-const readMaskedInput = (prompt: string): Promise<string> => {
-  return new Promise((resolve) => {
-    process.stdout.write(prompt);
+export const handleSetupCommand = async (): Promise<void> => {
+  clack.intro("pdf-analyzer setup");
 
-    const chars: string[] = [];
+  const existingProvider = getActiveProvider();
+  const existingKey = getApiKey();
+  const existingModel = getModel();
 
-    if (!process.stdin.isTTY) {
-      // Non-TTY fallback: read a line normally
-      const onData = (data: Buffer) => {
-        process.stdin.removeListener("data", onData);
-        process.stdin.pause();
-        resolve(data.toString().trim());
-      };
-      process.stdin.resume();
-      process.stdin.setEncoding("utf8");
-      process.stdin.once("data", onData);
-      return;
-    }
-
-    process.stdin.setRawMode(true);
-    process.stdin.resume();
-    process.stdin.setEncoding("utf8");
-
-    const onData = (key: string) => {
-      // Ctrl+C
-      if (key === "\u0003") {
-        process.stdin.setRawMode(false);
-        process.stdin.removeListener("data", onData);
-        process.stdin.pause();
-        process.stdout.write("\n");
-        process.exit(130);
-      }
-
-      // Enter
-      if (key === "\r" || key === "\n") {
-        process.stdin.setRawMode(false);
-        process.stdin.removeListener("data", onData);
-        process.stdin.pause();
-        process.stdout.write("\n");
-        resolve(chars.join(""));
-        return;
-      }
-
-      // Backspace / Delete
-      if (key === "\u007F" || key === "\b") {
-        if (chars.length > 0) {
-          chars.pop();
-          process.stdout.write("\b \b");
-        }
-        return;
-      }
-
-      // Regular character
-      chars.push(key);
-      process.stdout.write("*");
-    };
-
-    process.stdin.on("data", onData);
-  });
-};
-
-/**
- * Handle the --set-key flag: store Gemini API key in OS credential store.
- */
-export const handleSetKeyCommand = async (): Promise<void> => {
-  const existing = getStoredApiKey();
-
-  if (existing) {
-    const overwrite = await confirm("A Gemini API key is already stored. Overwrite it?");
-    if (!overwrite) {
-      console.log("Cancelled.");
+  if (existingProvider && existingKey) {
+    const providerConfig = providerList.find((p) => p.id === existingProvider);
+    const providerName = providerConfig?.displayName ?? existingProvider;
+    const modelName =
+      providerConfig?.models.find((m) => m.id === existingModel)?.displayName ?? existingModel;
+    const shouldReconfigure = await clack.confirm({
+      message: `Already configured with ${providerName} (${modelName}). Reconfigure?`,
+    });
+    assertNotCancelled(shouldReconfigure);
+    if (!shouldReconfigure) {
+      clack.outro("No changes made.");
       return;
     }
   }
 
-  const key = await readMaskedInput("Enter your Gemini API key: ");
+  const providerId = await clack.select({
+    message: "Choose your LLM provider",
+    options: providerList.map((p) => ({
+      value: p.id,
+      label: p.displayName,
+    })),
+  });
+  assertNotCancelled(providerId);
 
-  if (!key) {
-    console.error("No key entered.");
-    process.exit(1);
-  }
+  const selected = providerList.find((p) => p.id === providerId)!;
+
+  const modelId = await clack.select({
+    message: "Choose a model",
+    options: selected.models.map((m) => ({
+      value: m.id,
+      label: `${m.displayName} - ${m.hint}`,
+    })),
+  });
+  assertNotCancelled(modelId);
+
+  const selectedModel = selected.models.find((m) => m.id === modelId)!;
+
+  clack.note(
+    `Model: ${selectedModel.displayName} (${modelId})\nGet your API key from: ${selected.apiKeyUrl}`,
+    selected.displayName
+  );
+
+  const key = await clack.password({
+    message: "Enter your API key",
+    validate: (value) => {
+      if (!value) return "API key is required";
+    },
+  });
+  assertNotCancelled(key);
 
   try {
-    setStoredApiKey(key);
-    console.log("API key stored successfully.");
+    setActiveProvider(selected.id);
+    setModel(modelId);
+    setApiKey(key);
+    clack.outro(`${selected.displayName} (${selectedModel.displayName}) configured successfully.`);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
-    console.error(`Failed to store API key: ${message}`);
+    clack.cancel(`Failed to store credentials: ${message}`);
     process.exit(1);
   }
+};
+
+/**
+ * Handle the deprecated --set-key flag.
+ */
+export const handleSetKeyCommand = async (): Promise<void> => {
+  clack.log.warn("--set-key is deprecated. Use --setup instead.");
+  await handleSetupCommand();
 };
 
 /**
@@ -200,7 +188,7 @@ export const handleUpdateCommand = async (): Promise<void> => {
     process.exit(1);
   }
 
-  console.log(`Update available: ${VERSION} → ${check.latestVersion}`);
+  console.log(`Update available: ${VERSION} -> ${check.latestVersion}`);
   console.log("Downloading...");
 
   const result = await performUpdate(check.downloadUrl, check.latestVersion);
@@ -210,8 +198,6 @@ export const handleUpdateCommand = async (): Promise<void> => {
     process.exit(1);
   }
 
-  // On Windows, we need to ensure stdout is flushed before exiting
-  // because replacing the running executable can cause issues
   const message = `Successfully updated to ${result.newVersion}\n`;
   await new Promise<void>((resolve) => {
     process.stdout.write(message, () => resolve());
@@ -231,10 +217,13 @@ export const handleUninstallCommand = async (): Promise<void> => {
   console.log(`  - Binary: ${binaryPath}`);
   console.log(`  - Directory: ${installDir}`);
   console.log("  - PATH entries from shell config files");
-  console.log("  - Stored API key from OS credential store");
+  console.log("  - Stored credentials from OS credential store");
   console.log("");
 
-  const confirmed = await confirm("Are you sure you want to uninstall?");
+  const confirmed = await clack.confirm({
+    message: "Are you sure you want to uninstall?",
+  });
+  assertNotCancelled(confirmed);
 
   if (!confirmed) {
     console.log("Uninstall cancelled.");
@@ -243,9 +232,9 @@ export const handleUninstallCommand = async (): Promise<void> => {
 
   console.log("");
 
-  // Remove stored API key from OS credential store
-  deleteStoredApiKey();
-  console.log("Removed stored API key");
+  // Remove all stored credentials
+  deleteAllCredentials();
+  console.log("Removed stored credentials");
 
   // Remove PATH entries from shell rc files
   const modifiedFiles = removeFromPath();

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@
  *
  * CLI flags:
  *   --version, -v    Print version and exit
- *   --set-key        Store Gemini API key in OS credential store
+ *   --setup          Choose LLM provider and store API key
+ *   --set-key        Deprecated alias for --setup
  *   --update         Check for updates and apply if available
  *   --uninstall      Remove pdf-analyzer from the system
  *   --help, -h       Show help
@@ -18,6 +19,7 @@ import { autoUpdate, reexec } from "./cli/updater.js";
 import {
   printVersion,
   printHelp,
+  handleSetupCommand,
   handleSetKeyCommand,
   handleUpdateCommand,
   handleUninstallCommand,
@@ -42,7 +44,13 @@ const main = async (): Promise<void> => {
     return;
   }
 
-  // Handle --set-key
+  // Handle --setup
+  if (args.includes("--setup")) {
+    await handleSetupCommand();
+    return;
+  }
+
+  // Handle --set-key (deprecated alias)
   if (args.includes("--set-key")) {
     await handleSetKeyCommand();
     return;

--- a/src/keychain.test.ts
+++ b/src/keychain.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { execSync } from "node:child_process";
-import {
-  escapeShellArg,
-  getStoredApiKey,
-  setStoredApiKey,
-  deleteStoredApiKey,
-} from "./keychain.js";
+import { escapeShellArg, getStoredValue, setStoredValue, deleteStoredValue } from "./keychain.js";
 
 function hasSecretTool(): boolean {
   try {
@@ -55,58 +50,59 @@ describe("escapeShellArg", () => {
 });
 
 describe("platform dispatch", () => {
-  it("getStoredApiKey returns string or null", () => {
-    const result = getStoredApiKey();
+  it("getStoredValue returns string or null", () => {
+    const result = getStoredValue("API_KEY");
     expect(result === null || typeof result === "string").toBe(true);
   });
 
-  it("setStoredApiKey accepts a string", () => {
-    expect(() => setStoredApiKey).not.toThrow();
+  it("setStoredValue accepts a string", () => {
+    expect(() => setStoredValue).not.toThrow();
   });
 
-  it("deleteStoredApiKey does not throw", () => {
-    // deleteStoredApiKey is best-effort; should never throw
-    expect(() => deleteStoredApiKey()).not.toThrow();
+  it("deleteStoredValue does not throw", () => {
+    // deleteStoredValue is best-effort; should never throw
+    expect(() => deleteStoredValue("API_KEY", "pdf-analyzer-test")).not.toThrow();
   });
 });
 
 // Integration tests: only run on the current platform's credential store.
 // Uses a separate service name so tests never touch the real stored key.
 const TEST_SERVICE = "pdf-analyzer-test";
+const TEST_ACCOUNT = "TEST_KEY";
 
 describe.skipIf(process.platform !== "darwin")("macOS keychain integration", () => {
   const TEST_KEY = "test-key-vitest-" + Date.now();
 
-  it("round-trips a key through the keychain", () => {
-    setStoredApiKey(TEST_KEY, TEST_SERVICE);
+  it("round-trips a value through the keychain", () => {
+    setStoredValue(TEST_ACCOUNT, TEST_KEY, TEST_SERVICE);
     try {
-      expect(getStoredApiKey(TEST_SERVICE)).toBe(TEST_KEY);
+      expect(getStoredValue(TEST_ACCOUNT, TEST_SERVICE)).toBe(TEST_KEY);
     } finally {
-      deleteStoredApiKey(TEST_SERVICE);
+      deleteStoredValue(TEST_ACCOUNT, TEST_SERVICE);
     }
     // After deletion, should be null
-    expect(getStoredApiKey(TEST_SERVICE)).toBeNull();
+    expect(getStoredValue(TEST_ACCOUNT, TEST_SERVICE)).toBeNull();
   });
 
   it("handles keys with special characters", () => {
     const specialKey = "AIza!@#$%^&*()_+-=[]|:;<>?,.~`";
-    setStoredApiKey(specialKey, TEST_SERVICE);
+    setStoredValue(TEST_ACCOUNT, specialKey, TEST_SERVICE);
     try {
-      expect(getStoredApiKey(TEST_SERVICE)).toBe(specialKey);
+      expect(getStoredValue(TEST_ACCOUNT, TEST_SERVICE)).toBe(specialKey);
     } finally {
-      deleteStoredApiKey(TEST_SERVICE);
+      deleteStoredValue(TEST_ACCOUNT, TEST_SERVICE);
     }
   });
 
-  it("overwrites existing key with -U flag", () => {
+  it("overwrites existing value", () => {
     const first = "first-key-" + Date.now();
     const second = "second-key-" + Date.now();
-    setStoredApiKey(first, TEST_SERVICE);
+    setStoredValue(TEST_ACCOUNT, first, TEST_SERVICE);
     try {
-      setStoredApiKey(second, TEST_SERVICE);
-      expect(getStoredApiKey(TEST_SERVICE)).toBe(second);
+      setStoredValue(TEST_ACCOUNT, second, TEST_SERVICE);
+      expect(getStoredValue(TEST_ACCOUNT, TEST_SERVICE)).toBe(second);
     } finally {
-      deleteStoredApiKey(TEST_SERVICE);
+      deleteStoredValue(TEST_ACCOUNT, TEST_SERVICE);
     }
   });
 });
@@ -116,14 +112,14 @@ describe.skipIf(process.platform !== "linux" || !hasSecretTool())(
   () => {
     const TEST_KEY = "test-key-vitest-" + Date.now();
 
-    it("round-trips a key through secret-tool", () => {
-      setStoredApiKey(TEST_KEY, TEST_SERVICE);
+    it("round-trips a value through secret-tool", () => {
+      setStoredValue(TEST_ACCOUNT, TEST_KEY, TEST_SERVICE);
       try {
-        expect(getStoredApiKey(TEST_SERVICE)).toBe(TEST_KEY);
+        expect(getStoredValue(TEST_ACCOUNT, TEST_SERVICE)).toBe(TEST_KEY);
       } finally {
-        deleteStoredApiKey(TEST_SERVICE);
+        deleteStoredValue(TEST_ACCOUNT, TEST_SERVICE);
       }
-      expect(getStoredApiKey(TEST_SERVICE)).toBeNull();
+      expect(getStoredValue(TEST_ACCOUNT, TEST_SERVICE)).toBeNull();
     });
   }
 );
@@ -131,13 +127,13 @@ describe.skipIf(process.platform !== "linux" || !hasSecretTool())(
 describe.skipIf(process.platform !== "win32")("Windows credential manager integration", () => {
   const TEST_KEY = "test-key-vitest-" + Date.now();
 
-  it("round-trips a key through credential manager", () => {
-    setStoredApiKey(TEST_KEY, TEST_SERVICE);
+  it("round-trips a value through credential manager", () => {
+    setStoredValue(TEST_ACCOUNT, TEST_KEY, TEST_SERVICE);
     try {
-      expect(getStoredApiKey(TEST_SERVICE)).toBe(TEST_KEY);
+      expect(getStoredValue(TEST_ACCOUNT, TEST_SERVICE)).toBe(TEST_KEY);
     } finally {
-      deleteStoredApiKey(TEST_SERVICE);
+      deleteStoredValue(TEST_ACCOUNT, TEST_SERVICE);
     }
-    expect(getStoredApiKey(TEST_SERVICE)).toBeNull();
+    expect(getStoredValue(TEST_ACCOUNT, TEST_SERVICE)).toBeNull();
   });
 });

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -1,5 +1,5 @@
 /**
- * OS-native credential storage for GEMINI_API_KEY.
+ * OS-native credential storage.
  *
  * Uses platform CLI tools (no native addons) so it works with Bun-compiled binaries.
  * - macOS: `security` CLI (Keychain Access)
@@ -9,8 +9,7 @@
 
 import { execSync } from "node:child_process";
 
-const DEFAULT_SERVICE_NAME = "pdf-analyzer";
-const ACCOUNT_NAME = "GEMINI_API_KEY";
+const DEFAULT_SERVICE = "pdf-analyzer";
 
 /** Stdio config that prevents credential leaks to MCP stdio transport. */
 const SILENT_STDIO: ["pipe", "pipe", "pipe"] = ["pipe", "pipe", "pipe"];
@@ -27,10 +26,10 @@ export function escapeShellArg(arg: string): string {
 // macOS (Keychain)
 // ---------------------------------------------------------------------------
 
-function getMacOS(service: string): string | null {
+function getMacOS(service: string, account: string): string | null {
   try {
     return execSync(
-      `security find-generic-password -s ${escapeShellArg(service)} -a ${escapeShellArg(ACCOUNT_NAME)} -w`,
+      `security find-generic-password -s ${escapeShellArg(service)} -a ${escapeShellArg(account)} -w`,
       { stdio: SILENT_STDIO, encoding: "utf-8" }
     ).trim();
   } catch {
@@ -38,17 +37,17 @@ function getMacOS(service: string): string | null {
   }
 }
 
-function setMacOS(service: string, key: string): void {
+function setMacOS(service: string, account: string, value: string): void {
   execSync(
-    `security add-generic-password -s ${escapeShellArg(service)} -a ${escapeShellArg(ACCOUNT_NAME)} -w ${escapeShellArg(key)} -U`,
+    `security add-generic-password -s ${escapeShellArg(service)} -a ${escapeShellArg(account)} -w ${escapeShellArg(value)} -U`,
     { stdio: SILENT_STDIO }
   );
 }
 
-function deleteMacOS(service: string): void {
+function deleteMacOS(service: string, account: string): void {
   try {
     execSync(
-      `security delete-generic-password -s ${escapeShellArg(service)} -a ${escapeShellArg(ACCOUNT_NAME)}`,
+      `security delete-generic-password -s ${escapeShellArg(service)} -a ${escapeShellArg(account)}`,
       { stdio: SILENT_STDIO }
     );
   } catch {
@@ -60,9 +59,14 @@ function deleteMacOS(service: string): void {
 // Windows (Credential Manager)
 // ---------------------------------------------------------------------------
 
-function getWindows(service: string): string | null {
+/** Build a Windows credential target from service + account. */
+function winTarget(service: string, account: string): string {
+  return `${service}/${account}`;
+}
+
+function getWindows(service: string, account: string): string | null {
   try {
-    // cmdkey cannot read credential values, so we use PowerShell with P/Invoke
+    const target = winTarget(service, account);
     const script = `
 Add-Type -Namespace Win32 -Name Cred -MemberDefinition @'
 [DllImport("advapi32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
@@ -78,7 +82,7 @@ public struct CREDENTIAL {
 }
 '@
 $ptr = [IntPtr]::Zero
-if ([Win32.Cred]::CredRead("${service}", 1, 0, [ref]$ptr)) {
+if ([Win32.Cred]::CredRead("${target}", 1, 0, [ref]$ptr)) {
   $c = [Runtime.InteropServices.Marshal]::PtrToStructure($ptr, [Type][Win32.Cred+CREDENTIAL])
   $secret = [Runtime.InteropServices.Marshal]::PtrToStringUni($c.CredentialBlob, $c.CredentialBlobSize/2)
   [Win32.Cred]::CredFree($ptr)
@@ -96,16 +100,18 @@ if ([Win32.Cred]::CredRead("${service}", 1, 0, [ref]$ptr)) {
   }
 }
 
-function setWindows(service: string, key: string): void {
-  execSync(`cmdkey /generic:${service} /user:${ACCOUNT_NAME} /pass:${escapeShellArg(key)}`, {
+function setWindows(service: string, account: string, value: string): void {
+  const target = winTarget(service, account);
+  execSync(`cmdkey /generic:${target} /user:${account} /pass:${escapeShellArg(value)}`, {
     stdio: SILENT_STDIO,
     shell: "cmd.exe",
   });
 }
 
-function deleteWindows(service: string): void {
+function deleteWindows(service: string, account: string): void {
   try {
-    execSync(`cmdkey /delete:${service}`, {
+    const target = winTarget(service, account);
+    execSync(`cmdkey /delete:${target}`, {
       stdio: SILENT_STDIO,
       shell: "cmd.exe",
     });
@@ -118,11 +124,11 @@ function deleteWindows(service: string): void {
 // Linux (libsecret / secret-tool)
 // ---------------------------------------------------------------------------
 
-function getLinux(service: string): string | null {
+function getLinux(service: string, account: string): string | null {
   try {
     return (
       execSync(
-        `secret-tool lookup service ${escapeShellArg(service)} username ${escapeShellArg(ACCOUNT_NAME)}`,
+        `secret-tool lookup service ${escapeShellArg(service)} username ${escapeShellArg(account)}`,
         { stdio: SILENT_STDIO, encoding: "utf-8" }
       ).trim() || null
     );
@@ -131,17 +137,17 @@ function getLinux(service: string): string | null {
   }
 }
 
-function setLinux(service: string, key: string): void {
+function setLinux(service: string, account: string, value: string): void {
   execSync(
-    `echo -n ${escapeShellArg(key)} | secret-tool store --label=${escapeShellArg(service)} service ${escapeShellArg(service)} username ${escapeShellArg(ACCOUNT_NAME)}`,
+    `echo -n ${escapeShellArg(value)} | secret-tool store --label=${escapeShellArg(service)} service ${escapeShellArg(service)} username ${escapeShellArg(account)}`,
     { stdio: SILENT_STDIO }
   );
 }
 
-function deleteLinux(service: string): void {
+function deleteLinux(service: string, account: string): void {
   try {
     execSync(
-      `secret-tool clear service ${escapeShellArg(service)} username ${escapeShellArg(ACCOUNT_NAME)}`,
+      `secret-tool clear service ${escapeShellArg(service)} username ${escapeShellArg(account)}`,
       { stdio: SILENT_STDIO }
     );
   } catch {
@@ -150,54 +156,103 @@ function deleteLinux(service: string): void {
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Generic credential operations
 // ---------------------------------------------------------------------------
 
-/** Read the stored API key from the OS credential store. Returns null if not found. */
-export function getStoredApiKey(service: string = DEFAULT_SERVICE_NAME): string | null {
+/** Read a value from the OS credential store. */
+export function getStoredValue(account: string, service: string = DEFAULT_SERVICE): string | null {
   switch (process.platform) {
     case "darwin":
-      return getMacOS(service);
+      return getMacOS(service, account);
     case "win32":
-      return getWindows(service);
+      return getWindows(service, account);
     case "linux":
-      return getLinux(service);
+      return getLinux(service, account);
     default:
       return null;
   }
 }
 
-/** Write the API key to the OS credential store. */
-export function setStoredApiKey(key: string, service: string = DEFAULT_SERVICE_NAME): void {
+/** Write a value to the OS credential store. */
+export function setStoredValue(
+  account: string,
+  value: string,
+  service: string = DEFAULT_SERVICE
+): void {
   switch (process.platform) {
     case "darwin":
-      setMacOS(service, key);
+      setMacOS(service, account, value);
       break;
     case "win32":
-      setWindows(service, key);
+      setWindows(service, account, value);
       break;
     case "linux":
-      setLinux(service, key);
+      setLinux(service, account, value);
       break;
     default:
       throw new Error(`Credential storage is not supported on ${process.platform}`);
   }
 }
 
-/** Remove the stored API key from the OS credential store (best-effort). */
-export function deleteStoredApiKey(service: string = DEFAULT_SERVICE_NAME): void {
+/** Remove a value from the OS credential store (best-effort). */
+export function deleteStoredValue(account: string, service: string = DEFAULT_SERVICE): void {
   switch (process.platform) {
     case "darwin":
-      deleteMacOS(service);
+      deleteMacOS(service, account);
       break;
     case "win32":
-      deleteWindows(service);
+      deleteWindows(service, account);
       break;
     case "linux":
-      deleteLinux(service);
+      deleteLinux(service, account);
       break;
     default:
       // No-op on unsupported platforms
       break;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience API for provider and API key storage
+// ---------------------------------------------------------------------------
+
+const PROVIDER_ACCOUNT = "PROVIDER";
+const API_KEY_ACCOUNT = "API_KEY";
+const MODEL_ACCOUNT = "MODEL";
+
+/** Get the active provider ID. Returns null if not set. */
+export function getActiveProvider(): string | null {
+  return getStoredValue(PROVIDER_ACCOUNT);
+}
+
+/** Store the active provider ID. */
+export function setActiveProvider(providerId: string): void {
+  setStoredValue(PROVIDER_ACCOUNT, providerId);
+}
+
+/** Get the stored API key. Returns null if not found. */
+export function getApiKey(): string | null {
+  return getStoredValue(API_KEY_ACCOUNT);
+}
+
+/** Store the API key. */
+export function setApiKey(key: string): void {
+  setStoredValue(API_KEY_ACCOUNT, key);
+}
+
+/** Get the stored model ID. Returns null if not set. */
+export function getModel(): string | null {
+  return getStoredValue(MODEL_ACCOUNT);
+}
+
+/** Store the selected model ID. */
+export function setModel(modelId: string): void {
+  setStoredValue(MODEL_ACCOUNT, modelId);
+}
+
+/** Delete all stored credentials (provider + API key + model). Best-effort. */
+export function deleteAllCredentials(): void {
+  deleteStoredValue(PROVIDER_ACCOUNT);
+  deleteStoredValue(API_KEY_ACCOUNT);
+  deleteStoredValue(MODEL_ACCOUNT);
 }

--- a/src/pdf-utils.ts
+++ b/src/pdf-utils.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared PDF utility functions.
+ *
+ * Contains URL validation, path validation, and PDF fetching logic
+ * used by both the service layer and provider implementations.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/** Gemini File API URI prefix. */
+const GEMINI_FILE_URI_PREFIX = "https://generativelanguage.googleapis.com/";
+
+/**
+ * Check if a string is a Gemini File API URI.
+ */
+export function isGeminiFileUri(source: string): boolean {
+  return source.startsWith(GEMINI_FILE_URI_PREFIX);
+}
+
+/**
+ * Check if a string is a URL (excluding Gemini File API URIs).
+ */
+export function isUrl(source: string): boolean {
+  if (isGeminiFileUri(source)) {
+    return false;
+  }
+  try {
+    const url = new URL(source);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates a local PDF file path.
+ * Throws descriptive errors for common issues.
+ */
+export function validateLocalPath(pdfPath: string): void {
+  const trimmedPath = pdfPath.trim();
+
+  if (!path.isAbsolute(trimmedPath)) {
+    throw new Error(`PDF path must be absolute: ${trimmedPath}`);
+  }
+
+  if (!fs.existsSync(trimmedPath)) {
+    throw new Error(`PDF file not found: ${trimmedPath}`);
+  }
+
+  const stats = fs.statSync(trimmedPath);
+  if (stats.isDirectory()) {
+    throw new Error(`Path is a directory, not a file: ${trimmedPath}`);
+  }
+
+  if (!trimmedPath.toLowerCase().endsWith(".pdf")) {
+    throw new Error(`File is not a PDF: ${trimmedPath}`);
+  }
+}
+
+/** Timeout for fetching PDFs from URLs (60 seconds). */
+const FETCH_TIMEOUT_MS = 60_000;
+
+/**
+ * Fetch PDF content from a URL with timeout.
+ */
+export async function fetchPdfFromUrl(url: string): Promise<Buffer> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(url, { signal: controller.signal });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`Request timed out after ${FETCH_TIMEOUT_MS / 1000}s`);
+    }
+    const message = error instanceof Error ? error.message : "Unknown error";
+    throw new Error(`Failed to fetch URL: ${message}`);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (
+    contentType &&
+    !contentType.includes("application/pdf") &&
+    !contentType.includes("octet-stream")
+  ) {
+    throw new Error(`URL does not point to a PDF file. Content-Type: ${contentType}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
+/**
+ * Read PDF bytes from a local file path.
+ */
+export function readPdfBytes(pdfPath: string): Buffer {
+  validateLocalPath(pdfPath);
+  return fs.readFileSync(pdfPath.trim());
+}

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,0 +1,77 @@
+/**
+ * Anthropic Claude provider.
+ *
+ * Sends PDFs inline as base64/bytes content parts.
+ * No File API, no caching.
+ */
+
+import { createAnthropic } from "@ai-sdk/anthropic";
+import type { ProviderConfig, ModelOption, PdfSource, PreparedPdf, PdfFilePart } from "./types.js";
+import { fetchPdfFromUrl, readPdfBytes } from "../pdf-utils.js";
+
+const MODELS: ModelOption[] = [
+  {
+    id: "claude-sonnet-4-6",
+    displayName: "Claude Sonnet 4.6",
+    hint: "Fast and cost-effective",
+  },
+  { id: "claude-opus-4-6", displayName: "Claude Opus 4.6", hint: "Best and most expensive" },
+];
+
+const DEFAULT_MODEL = "claude-opus-4-6";
+
+/**
+ * Prepare a PDF source for Anthropic by reading bytes inline.
+ */
+async function preparePdf(source: PdfSource): Promise<PreparedPdf> {
+  if (source.kind === "cachedUri") {
+    throw new Error("Cached URIs are only supported with the Google provider.");
+  }
+
+  let bytes: Uint8Array;
+
+  if (source.kind === "bytes") {
+    bytes = source.bytes;
+  } else if (source.kind === "url") {
+    bytes = new Uint8Array(await fetchPdfFromUrl(source.url));
+  } else {
+    bytes = new Uint8Array(await readPdfBytes(source.path));
+  }
+
+  const part: PdfFilePart = {
+    type: "file",
+    data: bytes,
+    mediaType: "application/pdf",
+  };
+  return { fileParts: [part], cachedUri: null };
+}
+
+/**
+ * Check if an error is an Anthropic token limit error.
+ */
+function isTokenLimitError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const msg = error.message.toLowerCase();
+  return (
+    msg.includes("too many input tokens") ||
+    msg.includes("prompt is too long") ||
+    msg.includes("maximum context length") ||
+    msg.includes("maximum of 100 pdf pages") ||
+    msg.includes("pdf pages may be provided")
+  );
+}
+
+export const anthropicProvider: ProviderConfig = {
+  id: "anthropic",
+  displayName: "Anthropic Claude",
+  models: MODELS,
+  defaultModel: DEFAULT_MODEL,
+  apiKeyUrl: "https://console.anthropic.com/settings/keys",
+  createModel: (apiKey: string, modelId: string) => {
+    const anthropic = createAnthropic({ apiKey });
+    return anthropic(modelId);
+  },
+  providerOptions: {},
+  preparePdf,
+  isTokenLimitError,
+};

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -1,0 +1,140 @@
+/**
+ * Google Gemini provider.
+ *
+ * Uses the Gemini File API for uploading PDFs (supports large files and caching),
+ * and the Vercel AI SDK for LLM calls.
+ */
+
+import { GoogleGenAI, ApiError } from "@google/genai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import type { ProviderConfig, ModelOption, PdfSource, PreparedPdf, PdfFilePart } from "./types.js";
+import { fetchPdfFromUrl, validateLocalPath } from "../pdf-utils.js";
+
+const MODELS: ModelOption[] = [
+  {
+    id: "gemini-3-flash-preview",
+    displayName: "Gemini 3 Flash",
+    hint: "Fast and cost-effective",
+  },
+  { id: "gemini-3.1-pro-preview", displayName: "Gemini 3.1 Pro", hint: "Best and most expensive" },
+];
+
+const DEFAULT_MODEL = "gemini-3.1-pro-preview";
+
+/** Gemini File API URI prefix. */
+const GEMINI_FILE_URI_PREFIX = "https://generativelanguage.googleapis.com/";
+
+/**
+ * Check if a string is a Gemini File API URI.
+ */
+export function isGeminiFileUri(source: string): boolean {
+  return source.startsWith(GEMINI_FILE_URI_PREFIX);
+}
+
+/**
+ * Wait for a file to finish processing on the Gemini File API.
+ */
+async function waitForFileReady(
+  client: GoogleGenAI,
+  fileName: string,
+  maxAttempts = 10
+): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const fileInfo = await client.files.get({ name: fileName });
+    if (fileInfo.state === "FAILED") {
+      throw new Error(`File processing failed: ${fileInfo.name}`);
+    }
+    if (fileInfo.state !== "PROCESSING") {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  throw new Error("File processing timed out");
+}
+
+/**
+ * Upload a PDF to the Gemini File API.
+ * Returns the Gemini File API URI.
+ */
+async function uploadToFileApi(client: GoogleGenAI, data: Blob | string): Promise<string> {
+  const file = await client.files.upload(
+    typeof data === "string"
+      ? { file: data, config: { mimeType: "application/pdf" } }
+      : { file: data, config: { mimeType: "application/pdf" } }
+  );
+
+  if (!file.name || !file.uri) {
+    throw new Error("File upload failed: missing name or URI");
+  }
+
+  await waitForFileReady(client, file.name);
+  return file.uri;
+}
+
+/**
+ * Prepare a PDF source for Google Gemini.
+ * Uploads to the File API and returns a URL-based file part.
+ */
+async function preparePdf(source: PdfSource, apiKey: string): Promise<PreparedPdf> {
+  const client = new GoogleGenAI({ apiKey });
+
+  if (source.kind === "cachedUri") {
+    const part: PdfFilePart = {
+      type: "file",
+      data: new URL(source.uri),
+      mediaType: "application/pdf",
+    };
+    return { fileParts: [part], cachedUri: source.uri };
+  }
+
+  let fileUri: string;
+
+  if (source.kind === "bytes") {
+    const blob = new Blob([source.bytes], { type: "application/pdf" });
+    fileUri = await uploadToFileApi(client, blob);
+  } else if (source.kind === "url") {
+    const pdfBuffer = await fetchPdfFromUrl(source.url);
+    const blob = new Blob([pdfBuffer], { type: "application/pdf" });
+    fileUri = await uploadToFileApi(client, blob);
+  } else {
+    validateLocalPath(source.path);
+    fileUri = await uploadToFileApi(client, source.path);
+  }
+
+  const part: PdfFilePart = {
+    type: "file",
+    data: new URL(fileUri),
+    mediaType: "application/pdf",
+  };
+  return { fileParts: [part], cachedUri: fileUri };
+}
+
+/**
+ * Check if an error is a Gemini token limit error.
+ */
+function isTokenLimitError(error: unknown): boolean {
+  if (error instanceof ApiError) {
+    return error.status === 400 && error.message.includes("input token count exceeds");
+  }
+  if (error instanceof Error) {
+    return error.message.includes("input token count exceeds");
+  }
+  return false;
+}
+
+export const googleProvider: ProviderConfig = {
+  id: "google",
+  displayName: "Google Gemini",
+  models: MODELS,
+  defaultModel: DEFAULT_MODEL,
+  apiKeyUrl: "https://aistudio.google.com/apikey",
+  createModel: (apiKey: string, modelId: string) => {
+    const google = createGoogleGenerativeAI({ apiKey });
+    return google(modelId);
+  },
+  providerOptions: {
+    google: { thinkingConfig: { thinkingLevel: "low" } },
+  },
+  preparePdf,
+  isTokenLimitError,
+};

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,0 +1,78 @@
+/**
+ * OpenAI provider.
+ *
+ * Sends PDFs inline as bytes content parts.
+ * No File API, no caching.
+ */
+
+import { createOpenAI } from "@ai-sdk/openai";
+import type { ProviderConfig, ModelOption, PdfSource, PreparedPdf, PdfFilePart } from "./types.js";
+import { fetchPdfFromUrl, readPdfBytes } from "../pdf-utils.js";
+
+const MODELS: ModelOption[] = [
+  {
+    id: "gpt-5.4-mini",
+    displayName: "GPT-5.4 Mini",
+    hint: "Fast and cost-effective",
+  },
+  { id: "gpt-5.4", displayName: "GPT-5.4", hint: "Best and most expensive" },
+];
+
+const DEFAULT_MODEL = "gpt-5.4";
+
+/**
+ * Prepare a PDF source for OpenAI by reading bytes inline.
+ */
+async function preparePdf(source: PdfSource): Promise<PreparedPdf> {
+  if (source.kind === "cachedUri") {
+    throw new Error("Cached URIs are only supported with the Google provider.");
+  }
+
+  let bytes: Uint8Array;
+
+  if (source.kind === "bytes") {
+    bytes = source.bytes;
+  } else if (source.kind === "url") {
+    bytes = new Uint8Array(await fetchPdfFromUrl(source.url));
+  } else {
+    bytes = new Uint8Array(await readPdfBytes(source.path));
+  }
+
+  const part: PdfFilePart = {
+    type: "file",
+    data: bytes,
+    mediaType: "application/pdf",
+  };
+  return { fileParts: [part], cachedUri: null };
+}
+
+/**
+ * Check if an error is an OpenAI token limit error.
+ */
+function isTokenLimitError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const msg = error.message.toLowerCase();
+  return (
+    msg.includes("maximum context length") ||
+    msg.includes("exceeds the context window") ||
+    msg.includes("too many tokens") ||
+    msg.includes("request too large")
+  );
+}
+
+export const openaiProvider: ProviderConfig = {
+  id: "openai",
+  displayName: "OpenAI GPT",
+  models: MODELS,
+  defaultModel: DEFAULT_MODEL,
+  apiKeyUrl: "https://platform.openai.com/api-keys",
+  createModel: (apiKey: string, modelId: string) => {
+    const openai = createOpenAI({ apiKey });
+    return openai(modelId);
+  },
+  providerOptions: {
+    openai: { reasoningEffort: "low" },
+  },
+  preparePdf,
+  isTokenLimitError,
+};

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1,0 +1,65 @@
+/**
+ * Provider registry.
+ *
+ * Maps provider IDs to their configurations and resolves
+ * the active provider from the OS credential store.
+ */
+
+import type { ProviderConfig } from "./types.js";
+import { googleProvider } from "./google.js";
+import { anthropicProvider } from "./anthropic.js";
+import { openaiProvider } from "./openai.js";
+import { getActiveProvider as getStoredProvider, getApiKey, getModel } from "../keychain.js";
+
+/** All supported providers, keyed by ID. */
+export const providers: Record<string, ProviderConfig> = {
+  google: googleProvider,
+  anthropic: anthropicProvider,
+  openai: openaiProvider,
+};
+
+/** Ordered list for display in the setup menu. */
+export const providerList: ProviderConfig[] = [googleProvider, anthropicProvider, openaiProvider];
+
+/**
+ * Resolve the active provider and API key from the credential store.
+ * Returns the provider config and the API key.
+ *
+ * Throws if no provider is configured or the API key is missing.
+ */
+export function resolveActiveProvider(): {
+  provider: ProviderConfig;
+  apiKey: string;
+  modelId: string;
+} {
+  const providerId = getStoredProvider();
+  const apiKey = getApiKey();
+
+  if (!providerId) {
+    throw new Error(
+      "No provider configured. Run `pdf-analyzer --setup` to choose a provider and set your API key."
+    );
+  }
+
+  const provider = providers[providerId];
+
+  if (!provider) {
+    throw new Error(
+      `Unknown provider "${providerId}". Run \`pdf-analyzer --setup\` to reconfigure.`
+    );
+  }
+
+  if (!apiKey) {
+    throw new Error(
+      `API key not found for ${provider.displayName}. Run \`pdf-analyzer --setup\` to set your API key.`
+    );
+  }
+
+  const storedModel = getModel();
+  const modelId =
+    storedModel && provider.models.some((m) => m.id === storedModel)
+      ? storedModel
+      : provider.defaultModel;
+
+  return { provider, apiKey, modelId };
+}

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,67 @@
+import type { LanguageModel } from "ai";
+
+/**
+ * A file content part compatible with the AI SDK message format.
+ */
+export interface PdfFilePart {
+  type: "file";
+  data: Uint8Array | URL;
+  mediaType: "application/pdf";
+}
+
+/**
+ * A prepared PDF ready for inclusion in an AI SDK message.
+ */
+export interface PreparedPdf {
+  /** Content parts to include in the AI SDK user message. */
+  fileParts: PdfFilePart[];
+  /** Gemini File API URI for caching (Google only; null for others). */
+  cachedUri: string | null;
+}
+
+/**
+ * Source of a PDF to analyze. Discriminated union by `kind`.
+ */
+export type PdfSource =
+  | { kind: "path"; path: string }
+  | { kind: "url"; url: string }
+  | { kind: "bytes"; bytes: Uint8Array }
+  | { kind: "cachedUri"; uri: string };
+
+/**
+ * A model option available for selection during setup.
+ */
+export interface ModelOption {
+  /** Model ID passed to the AI SDK, e.g. "gemini-3.1-pro-preview". */
+  id: string;
+  /** Display name shown in the setup TUI. */
+  displayName: string;
+  /** Short hint shown next to the model name. */
+  hint: string;
+}
+
+/**
+ * Configuration for an LLM provider.
+ * Each provider exports a plain object satisfying this interface.
+ */
+export interface ProviderConfig {
+  /** Provider identifier, e.g. "google", "anthropic", "openai". */
+  id: string;
+  /** Display name shown during setup. */
+  displayName: string;
+  /** Available models for this provider. */
+  models: ModelOption[];
+  /** Default (flagship) model ID, used as fallback. */
+  defaultModel: string;
+  /** URL where the user obtains an API key. */
+  apiKeyUrl: string;
+  /** Create an AI SDK LanguageModel instance for the given model ID. */
+  createModel: (apiKey: string, modelId: string) => LanguageModel;
+  /** Provider-specific options for generateText (e.g. thinking/reasoning config). */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  providerOptions: Record<string, any>;
+  /** Prepare a PDF source for inclusion in an LLM call. */
+  preparePdf: (source: PdfSource, apiKey: string) => Promise<PreparedPdf>;
+  /** Check if an error indicates input token limit exceeded (triggers chunking). */
+  isTokenLimitError: (error: unknown) => boolean;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,14 +1,16 @@
 /**
  * PDF Analyzer MCP Server
  *
- * Model Context Protocol server for analyzing PDF documents using Gemini API.
+ * Model Context Protocol server for analyzing PDF documents using
+ * a configurable LLM provider (Google Gemini, Anthropic Claude, or OpenAI).
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { VERSION } from "./version.js";
-import { createGeminiClient, analyzePdf, isApiError, getApiErrorMessage } from "./service.js";
+import { analyzePdf } from "./service.js";
+import { resolveActiveProvider } from "./providers/registry.js";
 
 // =============================================================================
 // Server Instructions
@@ -17,38 +19,38 @@ import { createGeminiClient, analyzePdf, isApiError, getApiErrorMessage } from "
 const SERVER_INSTRUCTIONS = `
 # PDF Analyzer MCP Server
 
-Analyzes PDF documents using Gemini's vision capabilities.
+Analyzes PDF documents using AI vision capabilities. Supports multiple LLM providers
+(Google Gemini, Anthropic Claude, OpenAI).
 
 ## Tool: analyze_pdf
 
-Pass an absolute file path, URL, or Gemini file URI(s) and a list of queries. The server reads the PDF,
-sends it to Gemini with your queries, and returns structured responses.
+Pass an absolute file path, URL, or cached file URI(s) and a list of queries. The server reads the PDF,
+sends it to the configured LLM with your queries, and returns structured responses.
 
-Large PDFs that exceed Gemini's token limit are automatically split into chunks and processed
+Large PDFs that exceed the model's token limit are automatically split into chunks and processed
 sequentially with rolling context. No user intervention is needed.
 
-## Caching Strategy
+## Caching Strategy (Google provider only)
 
-The response includes a \`cached_uris\` array (Gemini File API URIs) that you should reuse for subsequent
-queries on the same document. This avoids re-uploading and is cached by Gemini for 48 hours.
+When using Google Gemini, the response includes a \`cached_uris\` array (Gemini File API URIs)
+that you should reuse for subsequent queries on the same document. This avoids re-uploading
+and is cached by Gemini for 48 hours. Other providers return an empty \`cached_uris\` array.
 
 **Input types accepted:**
 - Local file path: \`/Users/name/docs/report.pdf\`
 - Web URL: \`https://example.com/doc.pdf\`
-- Gemini file URI: \`https://generativelanguage.googleapis.com/v1beta/files/abc123\` (from previous response)
-- Array of Gemini file URIs: for re-analyzing a previously chunked document
+- Gemini file URI: \`https://generativelanguage.googleapis.com/v1beta/files/abc123\` (Google only, from previous response)
+- Array of Gemini file URIs: for re-analyzing a previously chunked document (Google only)
 
-**Workflow for multiple queries on same document:**
-1. First call: pass local path or URL → receive \`cached_uris\` in response
-2. Subsequent calls: pass the \`cached_uris\` value as \`pdf_source\` → no re-upload, faster response
-   - If \`cached_uris\` has one element, pass the single URI string
-   - If \`cached_uris\` has multiple elements (chunked PDF), pass the full array
+**Workflow for multiple queries on same document (Google provider):**
+1. First call: pass local path or URL -> receive \`cached_uris\` in response
+2. Subsequent calls: pass the \`cached_uris\` value as \`pdf_source\` -> no re-upload, faster response
 
 ## Usage Tips
 
 - Ask specific, focused queries for best results
 - For multi-page PDFs, reference page numbers in queries when relevant
-- Reuse the returned \`cached_uris\` for follow-up questions on the same document
+- With Google provider, reuse the returned \`cached_uris\` for follow-up questions
 
 ## Example
 
@@ -66,7 +68,7 @@ queries on the same document. This avoids re-uploading and is cached by Gemini f
 ## Error Handling
 
 Common errors and solutions:
-- Missing GEMINI_API_KEY: Run \`pdf-analyzer --set-key\` to store your API key
+- Missing provider/API key: Run \`pdf-analyzer --setup\` to choose a provider and store your API key
 - PDF not found: Verify the path is absolute and file exists
 - URL fetch failed: Check that the URL is accessible and points to a valid PDF
 `.trim();
@@ -127,12 +129,12 @@ export const createServer = (): McpServer => {
     "analyze_pdf",
     {
       description:
-        "Analyze a PDF document using Gemini AI. Provide an absolute file path, URL, Gemini file URI (from a previous response), or array of Gemini file URIs (from a previous chunked response) and a list of questions to ask about the PDF content. Returns a cached_uris array that can be reused for subsequent queries on the same document (cached by Gemini for 48 hours).",
+        "Analyze a PDF document using AI. Provide an absolute file path, URL, cached file URI (from a previous response, Google only), or array of cached file URIs (from a previous chunked response, Google only) and a list of questions to ask about the PDF content. With the Google provider, returns a cached_uris array that can be reused for subsequent queries on the same document.",
       inputSchema: {
         pdf_source: z
           .union([z.string(), z.array(z.string().min(1)).min(1)])
           .describe(
-            "PDF source: absolute local file path (e.g., /Users/name/docs/report.pdf), URL (e.g., https://example.com/doc.pdf), Gemini file URI from a previous response (e.g., https://generativelanguage.googleapis.com/v1beta/files/abc123), or array of Gemini file URIs from a previous chunked response"
+            "PDF source: absolute local file path, URL, cached file URI from a previous response (Google only), or array of cached file URIs from a previous chunked response (Google only)"
           ),
         queries: z
           .array(z.string().min(1))
@@ -142,28 +144,21 @@ export const createServer = (): McpServer => {
     },
     async ({ pdf_source, queries }) => {
       try {
-        const client = createGeminiClient();
-        const result = await analyzePdf(client, { pdf_source, queries });
+        const { provider, apiKey, modelId } = resolveActiveProvider();
+        const result = await analyzePdf(provider, apiKey, modelId, { pdf_source, queries });
         return formatResult(result);
       } catch (error) {
-        // Handle typed Gemini API errors
-        if (isApiError(error)) {
-          const { message, details } = getApiErrorMessage(error);
-          return formatError(message, details);
-        }
-
         const message = error instanceof Error ? error.message : "Unknown error occurred";
 
-        // Provide helpful context for common errors
-        if (message.includes("GEMINI_API_KEY")) {
-          return formatError(message, "Run `pdf-analyzer --set-key` to store your Gemini API key.");
+        if (message.includes("No provider configured") || message.includes("API key not found")) {
+          return formatError(message);
         }
 
         if (message.includes("not found")) {
           return formatError(message, "Ensure the path is absolute and the file exists.");
         }
 
-        if (message.includes("Failed to fetch PDF from URL")) {
+        if (message.includes("Failed to fetch")) {
           return formatError(
             message,
             "Check that the URL is accessible and points to a valid PDF file."

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,187 +1,20 @@
-import { GoogleGenAI, ApiError } from "@google/genai";
-import * as fs from "node:fs";
-import * as path from "node:path";
+import { generateText, Output } from "ai";
 import type {
   AnalyzePdfInput,
   AnalyzePdfResponse,
   ChunkedQueryResponse,
   QueryResponse,
 } from "./types.js";
-import { ChunkedGeminiResponseSchema, GeminiResponseSchema } from "./types.js";
+import { ResponseSchema, ChunkedResponseSchema } from "./types.js";
 import { pdfBytesToChunk, splitPdfInHalf } from "./chunker.js";
 import type { PdfChunk } from "./chunker.js";
-import { getStoredApiKey } from "./keychain.js";
-
-const GEMINI_MODEL = "gemini-3.1-pro-preview";
+import type { ProviderConfig, PdfSource } from "./providers/types.js";
+import { isGeminiFileUri, isUrl, fetchPdfFromUrl, readPdfBytes } from "./pdf-utils.js";
 
 const SYSTEM_INSTRUCTION = `You are a document analysis assistant. Analyze PDF documents and answer questions based on their content.
 For each question, provide a clear, detailed answer based on the content of the PDF.
 If the answer cannot be determined from the PDF, say so explicitly.
 Always respond with accurate information from the document.`;
-
-/** Gemini File API URI prefix */
-const GEMINI_FILE_URI_PREFIX = "https://generativelanguage.googleapis.com/";
-
-/**
- * Creates and returns a configured GoogleGenAI client.
- * Reads GEMINI_API_KEY from the OS credential store.
- */
-export function createGeminiClient(): GoogleGenAI {
-  const apiKey = getStoredApiKey();
-  if (!apiKey) {
-    throw new Error(
-      "GEMINI_API_KEY not found. Run `pdf-analyzer --set-key` to store your key. " +
-        "Get your key from https://aistudio.google.com/apikey"
-    );
-  }
-  return new GoogleGenAI({ apiKey });
-}
-
-/**
- * Check if a string is a Gemini File API URI.
- */
-export function isGeminiFileUri(source: string): boolean {
-  return source.startsWith(GEMINI_FILE_URI_PREFIX);
-}
-
-/**
- * Check if a string is a URL (excluding Gemini File API URIs).
- */
-export function isUrl(source: string): boolean {
-  if (isGeminiFileUri(source)) {
-    return false;
-  }
-  try {
-    const url = new URL(source);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Validates a local PDF file path.
- * Throws descriptive errors for common issues.
- */
-export function validateLocalPath(pdfPath: string): void {
-  const trimmedPath = pdfPath.trim();
-
-  if (!path.isAbsolute(trimmedPath)) {
-    throw new Error(`PDF path must be absolute: ${trimmedPath}`);
-  }
-
-  if (!fs.existsSync(trimmedPath)) {
-    throw new Error(`PDF file not found: ${trimmedPath}`);
-  }
-
-  const stats = fs.statSync(trimmedPath);
-  if (stats.isDirectory()) {
-    throw new Error(`Path is a directory, not a file: ${trimmedPath}`);
-  }
-
-  if (!trimmedPath.toLowerCase().endsWith(".pdf")) {
-    throw new Error(`File is not a PDF: ${trimmedPath}`);
-  }
-}
-
-/** Timeout for fetching PDFs from URLs (60 seconds) */
-const FETCH_TIMEOUT_MS = 60_000;
-
-/**
- * Fetch PDF content from a URL with timeout.
- */
-async function fetchPdfFromUrl(url: string): Promise<Buffer> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-  let response: Response;
-  try {
-    response = await fetch(url, { signal: controller.signal });
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      throw new Error(`Request timed out after ${FETCH_TIMEOUT_MS / 1000}s`);
-    }
-    const message = error instanceof Error ? error.message : "Unknown error";
-    throw new Error(`Failed to fetch URL: ${message}`);
-  } finally {
-    clearTimeout(timeoutId);
-  }
-
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-  }
-
-  const contentType = response.headers.get("content-type");
-  if (
-    contentType &&
-    !contentType.includes("application/pdf") &&
-    !contentType.includes("octet-stream")
-  ) {
-    throw new Error(`URL does not point to a PDF file. Content-Type: ${contentType}`);
-  }
-
-  const arrayBuffer = await response.arrayBuffer();
-  return Buffer.from(arrayBuffer);
-}
-
-/**
- * Wait for a file to finish processing.
- * Polls the file state until it's no longer PROCESSING.
- */
-async function waitForFileReady(
-  client: GoogleGenAI,
-  fileName: string,
-  maxAttempts = 10
-): Promise<void> {
-  for (let i = 0; i < maxAttempts; i++) {
-    const fileInfo = await client.files.get({ name: fileName });
-    if (fileInfo.state === "FAILED") {
-      throw new Error(`File processing failed: ${fileInfo.name}`);
-    }
-    if (fileInfo.state !== "PROCESSING") {
-      return; // File is ready (ACTIVE state)
-    }
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-  }
-  throw new Error("File processing timed out");
-}
-
-/**
- * Upload a PDF to the Gemini File API, or return the URI if already a Gemini file.
- * Accepts local paths, web URLs, or Gemini File API URIs.
- * Returns the Gemini URI for use in subsequent calls.
- */
-async function uploadPdf(client: GoogleGenAI, source: string): Promise<string> {
-  // If already a Gemini file URI, return as-is (no upload needed)
-  if (isGeminiFileUri(source)) {
-    return source;
-  }
-
-  // Upload the file
-  let file;
-  if (isUrl(source)) {
-    const pdfBuffer = await fetchPdfFromUrl(source);
-    file = await client.files.upload({
-      file: new Blob([pdfBuffer], { type: "application/pdf" }),
-      config: { mimeType: "application/pdf" },
-    });
-  } else {
-    validateLocalPath(source);
-    file = await client.files.upload({
-      file: source,
-      config: { mimeType: "application/pdf" },
-    });
-  }
-
-  if (!file.name || !file.uri) {
-    throw new Error("File upload failed: missing name or URI");
-  }
-
-  // Wait for file to be ready
-  await waitForFileReady(client, file.name);
-
-  return file.uri;
-}
 
 /**
  * Build the user prompt with queries.
@@ -191,7 +24,7 @@ function buildUserPrompt(queries: string[]): string {
   return `Please analyze the attached PDF and answer these questions:\n\n${queriesText}`;
 }
 
-/** Maximum chunk size for File API upload: 50MB × 0.85 safety margin */
+/** Maximum chunk size for File API upload: 50MB x 0.85 safety margin. */
 const MAX_UPLOAD_BYTES = 50 * 1024 * 1024 * 0.85;
 
 /**
@@ -213,64 +46,53 @@ function ensureAllQueriesAnswered(queries: string[], parsed: QueryResponse[]): Q
 
 /**
  * Direct single-file analysis path.
- * Uploads the PDF via File API and sends it to Gemini in one call.
+ * Prepares the PDF via the provider and sends it to the LLM in one call.
  */
 async function analyzePdfDirect(
-  client: GoogleGenAI,
-  source: string,
+  provider: ProviderConfig,
+  apiKey: string,
+  modelId: string,
+  source: PdfSource,
   queries: string[]
 ): Promise<AnalyzePdfResponse> {
-  const fileUri = await uploadPdf(client, source);
+  const prepared = await provider.preparePdf(source, apiKey);
 
-  const response = await client.models.generateContent({
-    model: GEMINI_MODEL,
-    contents: [
+  const model = provider.createModel(apiKey, modelId);
+  const { text } = await generateText({
+    model,
+    system: SYSTEM_INSTRUCTION,
+    output: Output.object({ schema: ResponseSchema }),
+    providerOptions: provider.providerOptions,
+    messages: [
       {
         role: "user",
-        parts: [
-          { fileData: { fileUri, mimeType: "application/pdf" } },
-          { text: buildUserPrompt(queries) },
-        ],
+        content: [...prepared.fileParts, { type: "text" as const, text: buildUserPrompt(queries) }],
       },
     ],
-    config: {
-      systemInstruction: SYSTEM_INSTRUCTION,
-      responseMimeType: "application/json",
-      responseSchema: GeminiResponseSchema,
-    },
   });
 
-  const responseText = response.text || "{}";
+  const responseText = text ?? "{}";
   const parsed = JSON.parse(responseText) as { responses: QueryResponse[] };
 
+  const pdfSourceValue =
+    source.kind === "cachedUri"
+      ? source.uri
+      : source.kind === "path"
+        ? source.path
+        : source.kind === "url"
+          ? source.url
+          : "bytes";
+
   return {
-    pdf_source: source,
-    cached_uris: [fileUri],
+    model: modelId,
+    pdf_source: pdfSourceValue,
+    cached_uris: prepared.cachedUri ? [prepared.cachedUri] : [],
     responses: ensureAllQueriesAnswered(queries, parsed.responses),
   };
 }
 
 /**
- * Upload raw PDF bytes to the Gemini File API.
- * Returns the Gemini URI for use in Gemini calls.
- */
-async function uploadChunkBytes(client: GoogleGenAI, chunkBytes: Uint8Array): Promise<string> {
-  const file = await client.files.upload({
-    file: new Blob([chunkBytes], { type: "application/pdf" }),
-    config: { mimeType: "application/pdf" },
-  });
-
-  if (!file.name || !file.uri) {
-    throw new Error("Chunk upload failed: missing name or URI");
-  }
-
-  await waitForFileReady(client, file.name);
-  return file.uri;
-}
-
-/**
  * Build system instruction for a chunk at a given position.
- * When `chunk` metadata is provided, page range info is included in the position line.
  */
 function buildChunkedSystemInstruction(
   chunkIndex: number,
@@ -280,7 +102,7 @@ function buildChunkedSystemInstruction(
 ): string {
   let position = `Processing chunk ${chunkIndex + 1} of ${totalChunks}`;
   if (chunk) {
-    const pageRange = `pages ${chunk.startPage + 1}–${chunk.startPage + chunk.pageCount}`;
+    const pageRange = `pages ${chunk.startPage + 1}\u2013${chunk.startPage + chunk.pageCount}`;
     position += ` (${pageRange} of ${chunk.totalPages} total)`;
   }
   position += ".";
@@ -298,7 +120,7 @@ In addition to answering the queries, produce a "findings_summary" field that tr
 
   if (chunkIndex === 0) {
     return `${base}
-This is the first chunk. Some answers may be incomplete — that's expected.${findingsInstruction}`;
+This is the first chunk. Some answers may be incomplete \u2014 that's expected.${findingsInstruction}`;
   }
 
   const previousContext = `
@@ -319,48 +141,32 @@ Provide final, comprehensive answers incorporating all findings across the entir
 }
 
 /**
- * Check if an error is a Gemini token limit error (input too large).
- */
-function isTokenLimitError(error: unknown): boolean {
-  if (!(error instanceof ApiError)) return false;
-  if (error.status !== 400) return false;
-  return error.message.includes("input token count exceeds");
-}
-
-/**
  * Process a work queue of PdfChunks, splitting on token limit errors.
- *
- * Algorithm:
- * 1. Shift a chunk from the queue
- * 2. Upload it and call Gemini
- * 3. On success: accumulate findings, collect cached_uri
- * 4. On token limit error: split the chunk in half, unshift both back
- * 5. Repeat until queue is empty
  */
 async function processChunkQueue(
-  client: GoogleGenAI,
+  provider: ProviderConfig,
+  apiKey: string,
+  modelId: string,
   queue: PdfChunk[],
   queries: string[],
   pdfSource: string | string[]
 ): Promise<AnalyzePdfResponse> {
   let previousFindings: string | null = null;
-  const fileUris: string[] = [];
+  const cachedUris: string[] = [];
   let processedCount = 0;
 
-  // We don't know total chunks upfront (splitting changes it),
-  // so we track completed chunks and estimate total as completed + remaining.
   while (queue.length > 0) {
     const chunk = queue.shift()!;
     const totalChunks = processedCount + 1 + queue.length;
 
-    // Pre-split chunks that exceed File API upload limit
+    // Pre-split chunks that exceed upload limit
     if (chunk.bytes.byteLength > MAX_UPLOAD_BYTES) {
       const [firstHalf, secondHalf] = await splitPdfInHalf(chunk);
       queue.unshift(firstHalf, secondHalf);
       continue;
     }
 
-    const fileUri = await uploadChunkBytes(client, chunk.bytes);
+    const prepared = await provider.preparePdf({ kind: "bytes", bytes: chunk.bytes }, apiKey);
 
     const systemInstruction = buildChunkedSystemInstruction(
       processedCount,
@@ -370,90 +176,92 @@ async function processChunkQueue(
     );
 
     try {
-      const response = await client.models.generateContent({
-        model: GEMINI_MODEL,
-        contents: [
+      const model = provider.createModel(apiKey, modelId);
+      const { text } = await generateText({
+        model,
+        system: systemInstruction,
+        output: Output.object({ schema: ChunkedResponseSchema }),
+        providerOptions: provider.providerOptions,
+        messages: [
           {
             role: "user",
-            parts: [
-              { fileData: { fileUri, mimeType: "application/pdf" } },
-              { text: buildUserPrompt(queries) },
+            content: [
+              ...prepared.fileParts,
+              { type: "text" as const, text: buildUserPrompt(queries) },
             ],
           },
         ],
-        config: {
-          systemInstruction,
-          responseMimeType: "application/json",
-          responseSchema: ChunkedGeminiResponseSchema,
-        },
       });
 
-      const responseText = response.text || "{}";
+      const responseText = text ?? "{}";
       const parsed = JSON.parse(responseText) as ChunkedQueryResponse;
       previousFindings = parsed.findings_summary;
-      fileUris.push(fileUri);
+      if (prepared.cachedUri) {
+        cachedUris.push(prepared.cachedUri);
+      }
       processedCount++;
 
-      // On the last chunk, return the final responses
       if (queue.length === 0) {
         return {
+          model: modelId,
           pdf_source: pdfSource,
-          cached_uris: fileUris,
+          cached_uris: cachedUris,
           responses: ensureAllQueriesAnswered(queries, parsed.responses),
         };
       }
     } catch (error) {
-      if (!isTokenLimitError(error)) throw error;
+      if (!provider.isTokenLimitError(error)) throw error;
 
-      // Token limit hit — split this chunk and retry
+      // Token limit hit, split this chunk and retry
       const [firstHalf, secondHalf] = await splitPdfInHalf(chunk);
       queue.unshift(firstHalf, secondHalf);
     }
   }
 
-  // Unreachable — loop returns on last successful chunk
   throw new Error("No chunks to process");
 }
 
 /**
  * Process an array of cached Gemini file URIs with rolling findings.
- * Used for re-analysis of a previously chunked PDF.
+ * Used for re-analysis of a previously chunked PDF (Google provider only).
  */
 async function processCachedUris(
-  client: GoogleGenAI,
+  provider: ProviderConfig,
+  apiKey: string,
+  modelId: string,
   fileUris: string[],
   queries: string[]
 ): Promise<AnalyzePdfResponse> {
   let previousFindings: string | null = null;
 
   for (let i = 0; i < fileUris.length; i++) {
-    const fileUri = fileUris[i];
+    const prepared = await provider.preparePdf({ kind: "cachedUri", uri: fileUris[i] }, apiKey);
     const systemInstruction = buildChunkedSystemInstruction(i, fileUris.length, previousFindings);
 
-    const response = await client.models.generateContent({
-      model: GEMINI_MODEL,
-      contents: [
+    const model = provider.createModel(apiKey, modelId);
+    const { text } = await generateText({
+      model,
+      system: systemInstruction,
+      output: Output.object({ schema: ChunkedResponseSchema }),
+      providerOptions: provider.providerOptions,
+      messages: [
         {
           role: "user",
-          parts: [
-            { fileData: { fileUri, mimeType: "application/pdf" } },
-            { text: buildUserPrompt(queries) },
+          content: [
+            ...prepared.fileParts,
+            { type: "text" as const, text: buildUserPrompt(queries) },
           ],
         },
       ],
-      config: {
-        systemInstruction,
-        responseMimeType: "application/json",
-        responseSchema: ChunkedGeminiResponseSchema,
-      },
     });
 
-    const responseText = response.text || "{}";
+    const responseText = text ?? "{}";
     const parsed = JSON.parse(responseText) as ChunkedQueryResponse;
     previousFindings = parsed.findings_summary;
 
     if (i === fileUris.length - 1) {
       return {
+        model: modelId,
         pdf_source: fileUris,
         cached_uris: fileUris,
         responses: ensureAllQueriesAnswered(queries, parsed.responses),
@@ -465,70 +273,70 @@ async function processCachedUris(
 }
 
 /**
- * Read PDF bytes from a source (URL or local file).
+ * Classify the pdf_source input into a PdfSource discriminated union.
  */
-async function readPdfBytes(source: string): Promise<Buffer> {
-  if (isUrl(source)) {
-    return fetchPdfFromUrl(source);
+function classifySource(source: string): PdfSource {
+  if (isGeminiFileUri(source)) {
+    return { kind: "cachedUri", uri: source };
   }
-  validateLocalPath(source);
-  return fs.readFileSync(source.trim());
+  if (isUrl(source)) {
+    return { kind: "url", url: source };
+  }
+  return { kind: "path", path: source };
 }
 
 /**
- * Analyzes a PDF document using Gemini.
+ * Analyzes a PDF document using the configured provider.
  *
  * Routing:
- * - string[] → cached chunk URIs, sequential processing with rolling findings
- * - Gemini URI string → direct single-file analysis (no bytes to split)
- * - path/URL → read bytes, try full PDF first, split on token limit error
+ * - string[] -> cached chunk URIs, sequential processing with rolling findings (Google only)
+ * - Gemini URI string -> direct single-file analysis via cached URI (Google only)
+ * - path/URL -> prepare via provider, try full PDF first, split on token limit error
  */
 export async function analyzePdf(
-  client: GoogleGenAI,
+  provider: ProviderConfig,
+  apiKey: string,
+  modelId: string,
   input: AnalyzePdfInput
 ): Promise<AnalyzePdfResponse> {
   const { pdf_source, queries } = input;
 
-  // Array of cached Gemini file URIs — re-analysis path
+  // Array of cached Gemini file URIs, re-analysis path (Google only)
   if (Array.isArray(pdf_source)) {
-    return processCachedUris(client, pdf_source, queries);
+    if (provider.id !== "google") {
+      throw new Error("Cached URIs are only supported with the Google provider.");
+    }
+    return processCachedUris(provider, apiKey, modelId, pdf_source, queries);
   }
 
-  // Single Gemini file URI — direct path, no splitting possible
-  if (isGeminiFileUri(pdf_source)) {
-    return analyzePdfDirect(client, pdf_source, queries);
+  const source = classifySource(pdf_source);
+
+  // Cached URI, direct path (Google only)
+  if (source.kind === "cachedUri") {
+    if (provider.id !== "google") {
+      throw new Error("Cached URIs are only supported with the Google provider.");
+    }
+    return analyzePdfDirect(provider, apiKey, modelId, source, queries);
   }
 
-  // Path or URL — try the full PDF first via the direct path
+  // Path or URL, try the full PDF first via the direct path
   try {
-    return await analyzePdfDirect(client, pdf_source, queries);
+    return await analyzePdfDirect(provider, apiKey, modelId, source, queries);
   } catch (error) {
-    if (!isTokenLimitError(error)) throw error;
+    if (!provider.isTokenLimitError(error)) throw error;
   }
 
-  // Token limit exceeded — read bytes, split into chunks, and process via work queue
-  const pdfBytes = await readPdfBytes(pdf_source);
+  // Token limit exceeded, read bytes, split into chunks, and process via work queue
+  // At this point source is "path" or "url" (cachedUri was handled above)
+  const pdfBytes =
+    source.kind === "url"
+      ? await fetchPdfFromUrl(source.url)
+      : readPdfBytes((source as { kind: "path"; path: string }).path);
   const initialChunk = await pdfBytesToChunk(new Uint8Array(pdfBytes));
-  return processChunkQueue(client, [initialChunk], queries, pdf_source);
+  return processChunkQueue(provider, apiKey, modelId, [initialChunk], queries, pdf_source);
 }
 
-/**
- * Check if an error is an ApiError and return typed error info.
- */
-export function isApiError(error: unknown): error is ApiError {
-  return error instanceof ApiError;
-}
-
-/**
- * Get error message from ApiError, preserving the actual API response.
- */
-export function getApiErrorMessage(error: ApiError): { message: string; details?: string } {
-  return {
-    message: `Gemini API error (HTTP ${error.status})`,
-    details: error.message,
-  };
-}
-
-// Re-export types that appear in public API signatures
+// Re-export types and utilities used by other modules
 export type { AnalyzePdfInput, AnalyzePdfResponse, QueryResponse } from "./types.js";
 export { AnalyzePdfInputSchema } from "./types.js";
+export { isGeminiFileUri, isUrl, validateLocalPath } from "./pdf-utils.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { Type, type Schema } from "@google/genai";
 
 /** Schema for the analyze_pdf tool input */
 export const AnalyzePdfInputSchema = z.object({
@@ -22,67 +21,39 @@ export interface QueryResponse {
 
 /** Response from the analyze_pdf tool */
 export interface AnalyzePdfResponse {
+  model: string;
   pdf_source: string | string[];
   cached_uris: string[];
   responses: QueryResponse[];
 }
 
 /**
- * Gemini response schema for structured output.
- * This ensures the model returns a predictable JSON structure.
+ * Zod schema for structured LLM output (single PDF).
+ * Used with AI SDK's Output.object().
  */
-export const GeminiResponseSchema: Schema = {
-  type: Type.OBJECT,
-  properties: {
-    responses: {
-      type: Type.ARRAY,
-      items: {
-        type: Type.OBJECT,
-        properties: {
-          query: { type: Type.STRING, description: "The original question" },
-          answer: { type: Type.STRING, description: "The answer based on PDF content" },
-        },
-        required: ["query", "answer"],
-      },
-      description: "Array of query-answer pairs",
-    },
-  },
-  required: ["responses"],
-};
+export const ResponseSchema = z.object({
+  responses: z.array(
+    z.object({
+      query: z.string().describe("The original question"),
+      answer: z.string().describe("The answer based on PDF content"),
+    })
+  ),
+});
 
 /**
- * Gemini response schema for chunked PDF processing.
- * Extends the base schema with a findings_summary field for rolling context.
+ * Zod schema for structured LLM output (chunked PDF).
+ * Extends the base schema with rolling findings.
  */
-export const ChunkedGeminiResponseSchema: Schema = {
-  type: Type.OBJECT,
-  properties: {
-    responses: {
-      type: Type.ARRAY,
-      items: {
-        type: Type.OBJECT,
-        properties: {
-          query: { type: Type.STRING, description: "The original question" },
-          answer: { type: Type.STRING, description: "The answer based on PDF content" },
-        },
-        required: ["query", "answer"],
-      },
-      description: "Array of query-answer pairs",
-    },
-    findings_summary: {
-      type: Type.STRING,
-      description:
-        "Summary of findings so far across all processed chunks. Include page citations, partial answers, and what remains unanswered.",
-    },
-  },
-  required: ["responses", "findings_summary"],
-};
+export const ChunkedResponseSchema = ResponseSchema.extend({
+  findings_summary: z
+    .string()
+    .describe(
+      "Summary of findings so far across all processed chunks. Include page citations, partial answers, and what remains unanswered."
+    ),
+});
 
-/** Response from a chunked Gemini call, including rolling findings */
-export interface ChunkedQueryResponse {
-  responses: QueryResponse[];
-  findings_summary: string;
-}
+/** Inferred type for chunked response */
+export type ChunkedQueryResponse = z.infer<typeof ChunkedResponseSchema>;
 
 /** Error response from the tool */
 export interface ToolError {

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,17 @@
+# Project TODO
+
+- [x] Add AI SDK dependencies (ai, @ai-sdk/google, @ai-sdk/anthropic, @ai-sdk/openai)
+- [x] Create provider types (src/providers/types.ts)
+- [x] Create Google provider (src/providers/google.ts)
+- [x] Create Anthropic provider (src/providers/anthropic.ts)
+- [x] Create OpenAI provider (src/providers/openai.ts)
+- [x] Create provider registry (src/providers/registry.ts)
+- [x] Extract shared PDF utilities (src/pdf-utils.ts)
+- [x] Refactor types.ts - replace Gemini schemas with Zod
+- [x] Refactor service.ts - use AI SDK generateText + Output.object
+- [x] Refactor keychain.ts - generalize to multi-account storage
+- [x] Refactor cli/commands.ts - --setup replaces --set-key
+- [x] Update server.ts - use provider registry
+- [x] Update index.ts - add --setup flag
+- [x] Update tests - all passing
+- [x] Cleanup: package.json, server instructions, CLAUDE.md


### PR DESCRIPTION
## Summary

- Migrate from Gemini-only to multi-provider architecture (Google Gemini, Anthropic Claude, OpenAI) via Vercel AI SDK V6
- Interactive TUI setup (`--setup`) with provider and model selection using @clack/prompts
- Fast and flagship model options per provider (e.g. Gemini 3 Flash vs 3.1 Pro, Sonnet 4.6 vs Opus 4.6, GPT-5.4 Mini vs GPT-5.4)
- Thinking/reasoning set to minimum across all providers for cost-efficient document analysis
- Adaptive PDF chunking works across all providers, not just Gemini
- Response includes `model` field showing which model was used

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (44 tests, 2 skipped)
- [x] Manual test: small PDF with Google Gemini (gemini-3-flash-preview)
- [x] Manual test: small PDF with Anthropic Claude (claude-opus-4-6)
- [x] Manual test: small PDF with OpenAI GPT (gpt-5.4-mini)
- [x] Manual test: oversized 980-page PDF triggers chunking
- [x] Manual test: `--setup` TUI flow with provider + model selection
- [x] Manual test: unconfigured provider returns setup instructions