### PR TITLE
fix(ci): use Node 24 for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,12 +182,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           # NOTE: Do NOT add registry-url here - it creates a .npmrc with
           # auth token placeholder that interferes with OIDC authentication
-
-      - name: Update npm to latest (OIDC requires npm 11.5.1+)
-        run: npm install -g npm@latest
+          # Node 24 ships with npm 11+ natively, no manual upgrade needed
 
       - name: Verify npm version
         run: npm --version


### PR DESCRIPTION
## Summary

- Switch npm publish job from Node 22 to Node 24
- Node 22.22.2 in GitHub Actions runner images ships with broken npm (missing `promise-retry` module), causing `npm install -g npm@latest` to fail
- Node 24 ships with npm 11+ natively, eliminating the self-upgrade step entirely

See: actions/runner-images#13883

## Test plan

- [ ] Re-run the v1.2.0 release after merge to verify npm publish succeeds