### PR TITLE
ci: strip Bun's ad-hoc signatures before lipo in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,13 @@ jobs:
           bun build --compile --minify --target=bun-linux-x64 --define BUILD_VERSION="\"$VERSION\"" src/index.ts --outfile bin/pdf-analyzer-linux-x64
           bun build --compile --minify --target=bun-windows-x64 --define BUILD_VERSION="\"$VERSION\"" src/index.ts --outfile bin/pdf-analyzer-windows-x64.exe
 
+          # Strip Bun's embedded ad-hoc signatures from each arch binary before
+          # lipo. Without this, `lipo -create` produces a fat binary whose
+          # signature slots are inconsistent and `codesign --force` later fails
+          # with "invalid or unsupported format for signature".
+          codesign --remove-signature bin/pdf-analyzer-darwin-arm64
+          codesign --remove-signature bin/pdf-analyzer-darwin-x64
+
           # Create macOS universal binary
           lipo -create bin/pdf-analyzer-darwin-arm64 bin/pdf-analyzer-darwin-x64 \
             -output bin/pdf-analyzer-darwin-universal


### PR DESCRIPTION
## Summary

v1.2.3's release run failed at the codesign step with:
```
pdf-analyzer-darwin-universal: invalid or unsupported format for signature
```

Root cause: Bun >= 1.3 embeds an ad-hoc Mach-O signature in every binary produced by \`--compile\`. When \`lipo -create\` concatenates two already-signed single-arch binaries into a universal fat binary, the resulting CodeDirectory slots are inconsistent, and \`codesign --force\` can't re-sign it cleanly.

Fix: strip each single-arch signature with \`codesign --remove-signature\` before \`lipo\`. The universal binary then starts unsigned and is cleanly re-signed by the existing sign step.

## Test plan

- [ ] PR checks green
- [ ] After merge, delete v1.2.3 tag, re-push from main, release workflow runs to completion (build-and-release + publish-npm both green)
- [ ] GitHub Release v1.2.3 exists with all 7 binaries attached
- [ ] \`npm view @intelligentelectron/pdf-analyzer version\` returns \`1.2.3\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)