### PR TITLE
fix: validate /analyze body via AnalyzePdfInputSchema

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -7,9 +7,9 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { z } from "zod";
 import { VERSION } from "./version.js";
 import { analyzePdf } from "./service.js";
+import { AnalyzePdfInputShape } from "./types.js";
 import { resolveActiveProvider } from "./providers/registry.js";
 // Cloud-only modules loaded lazily to avoid pulling in heavy deps in stdio mode.
 // import { startHttpServer } from "./transports/http.js";
@@ -138,17 +138,7 @@ export const createServer = (mode: "stdio" | "http" = "stdio"): McpServer => {
     "analyze_pdf",
     {
       description: mode === "http" ? ANALYZE_PDF_DESCRIPTION_HTTP : ANALYZE_PDF_DESCRIPTION_STDIO,
-      inputSchema: {
-        pdf_source: z
-          .union([z.string(), z.array(z.string().min(1)).min(1)])
-          .describe(
-            "PDF source: absolute local file path, URL, cached file URI from a previous response (Google only), or array of cached file URIs from a previous chunked response (Google only)"
-          ),
-        queries: z
-          .array(z.string().min(1))
-          .min(1)
-          .describe("Array of questions to ask about the PDF"),
-      },
+      inputSchema: AnalyzePdfInputShape,
     },
     async ({ pdf_source, queries }) => {
       try {

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -104,4 +104,73 @@ describe("HTTP transport", () => {
     const res = await fetch(`${baseUrl}/mcp`, { method: "DELETE" });
     expect(res.status).not.toBe(404);
   });
+
+  // Regression for #42: malformed /analyze bodies were reaching analyzePdf and
+  // crashing inside validateLocalPath with "Cannot read properties of undefined
+  // (reading 'trim')". The handler now runs zod up front so callers get a
+  // descriptive 400 instead.
+  describe("POST /analyze input validation", () => {
+    async function postAnalyze(baseUrl: string, body: unknown): Promise<Response> {
+      return fetch(`${baseUrl}/analyze`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    }
+
+    it("rejects missing pdf_source with 400 and a zod path", async () => {
+      const { baseUrl, server } = await startTestServer();
+      testServer = server;
+
+      const res = await postAnalyze(baseUrl, { queries: ["What is this?"] });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string; details: string[] };
+      expect(body.error).toBe("Invalid request body");
+      expect(body.details.join("\n")).toContain("pdf_source");
+    });
+
+    it("rejects non-string, non-array pdf_source with 400", async () => {
+      const { baseUrl, server } = await startTestServer();
+      testServer = server;
+
+      const res = await postAnalyze(baseUrl, { pdf_source: 123, queries: ["q"] });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string; details: string[] };
+      expect(body.details.join("\n")).toContain("pdf_source");
+    });
+
+    it("rejects empty queries array with 400", async () => {
+      const { baseUrl, server } = await startTestServer();
+      testServer = server;
+
+      const res = await postAnalyze(baseUrl, { pdf_source: "/tmp/x.pdf", queries: [] });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string; details: string[] };
+      expect(body.details.join("\n")).toContain("queries");
+    });
+
+    it("rejects empty-string queries with 400", async () => {
+      const { baseUrl, server } = await startTestServer();
+      testServer = server;
+
+      const res = await postAnalyze(baseUrl, { pdf_source: "/tmp/x.pdf", queries: [""] });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string; details: string[] };
+      expect(body.details.join("\n")).toContain("queries");
+    });
+
+    it("rejects non-JSON body with 400", async () => {
+      const { baseUrl, server } = await startTestServer();
+      testServer = server;
+
+      const res = await fetch(`${baseUrl}/analyze`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain("JSON");
+    });
+  });
 });

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -12,6 +12,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { analyzePdf } from "../service.js";
+import { AnalyzePdfInputSchema } from "../types.js";
 import { resolveActiveProvider } from "../providers/registry.js";
 
 /**
@@ -33,16 +34,29 @@ function readBody(req: IncomingMessage): Promise<string> {
  * Response body: AnalyzePdfResponse JSON
  */
 async function handleAnalyze(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  let body: unknown;
   try {
-    const body = JSON.parse(await readBody(req));
-    const { pdf_source, queries } = body;
-    if (!pdf_source || !queries || !Array.isArray(queries) || queries.length === 0) {
-      res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Required: pdf_source (string) and queries (string[])" }));
-      return;
-    }
+    body = JSON.parse(await readBody(req));
+  } catch {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Request body must be valid JSON" }));
+    return;
+  }
+
+  const parsed = AnalyzePdfInputSchema.safeParse(body);
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map((issue) => {
+      const pathStr = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      return `${pathStr}: ${issue.message}`;
+    });
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Invalid request body", details: issues }));
+    return;
+  }
+
+  try {
     const { provider, apiKey, modelId } = await resolveActiveProvider();
-    const result = await analyzePdf(provider, apiKey, modelId, { pdf_source, queries });
+    const result = await analyzePdf(provider, apiKey, modelId, parsed.data);
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(result));
   } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,17 @@
 import { z } from "zod";
 
-/** Schema for the analyze_pdf tool input */
-export const AnalyzePdfInputSchema = z.object({
+/** Field schemas for the analyze_pdf tool input. Shared between MCP and HTTP. */
+export const AnalyzePdfInputShape = {
   pdf_source: z
     .union([z.string(), z.array(z.string().min(1)).min(1)])
     .describe(
-      "PDF source: file path, URL, single Gemini file URI, or array of Gemini file URIs from a previous chunked response"
+      "PDF source: absolute local file path, URL, cached file URI from a previous response (Google only), or array of cached file URIs from a previous chunked response (Google only)"
     ),
   queries: z.array(z.string().min(1)).min(1).describe("Array of questions to ask about the PDF"),
-});
+};
+
+/** Schema for the analyze_pdf tool input */
+export const AnalyzePdfInputSchema = z.object(AnalyzePdfInputShape);
 
 /** Input type for the analyze_pdf tool */
 export type AnalyzePdfInput = z.infer<typeof AnalyzePdfInputSchema>;


### PR DESCRIPTION
## Summary

Closes #42 by fixing the actual root cause: the HTTP `/analyze` endpoint was hand-rolling a weaker validation than the MCP path, letting malformed bodies through.

- `src/transports/http.ts`: replace the `!pdf_source || !queries || ...` check with `AnalyzePdfInputSchema.safeParse(body)`. Returns 400 with zod's path-aware error details instead of a generic message.
- `src/types.ts`: hoist the field definitions into `AnalyzePdfInputShape` (single source of truth for both transports).
- `src/server.ts`: MCP `analyze_pdf` `inputSchema` now uses `AnalyzePdfInputShape`, eliminating the inline duplicate. Drops the unused `z` import.
- `src/transports/http.test.ts`: 5 new regression tests covering missing `pdf_source`, non-string `pdf_source`, empty `queries`, empty-string queries, and non-JSON bodies.

`src/pdf-utils.ts` is **untouched**. The defensive null/typeof guards from the previous version of this PR are not needed once the boundary validates strictly, and they would have masked future bugs in callers.

## Why this approach (vs. the original issue's spec)

The issue proposed adding null/undefined guards in `validateLocalPath`, `readPdfBytes`, `fetchPdfFromUrl`, `isUrl`, and `isGeminiFileUri`. That patches the symptom — by the time control reaches those internal helpers, `pdf_source` is already typed as `string` and any malformed value indicates a missed boundary check upstream. The actual upstream gap was `transports/http.ts:39`: the MCP transport already validated against the same zod schema, so this was duplicated validation that fell out of sync.

Fixing the boundary instead of the helpers:
- Eliminates 5 redundant runtime type checks per request.
- Keeps `pdf-utils.ts` honest about its `string` parameter type.
- Catches additional malformed cases the original issue's fix did not (numbers, objects, empty arrays as `pdf_source`).
- Improves error messages: clients now get `pdf_source: Invalid input` with the failing field path, instead of a hand-formatted English string.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test` — 98 passed / 2 skipped, including 5 new `/analyze` validation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)