### PR TITLE
v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.2.4] - 2026-05-08
+
+### Fixed
+- HTTP `/analyze` endpoint now validates request bodies against the same `AnalyzePdfInputSchema` used by the MCP path. Previously a hand-rolled truthy check accepted malformed `pdf_source` values (numbers, objects, etc.), which then crashed inside `validateLocalPath` with `Cannot read properties of undefined (reading 'trim')`. Malformed bodies now return `400` with zod's path-aware error details. (#42)
+
+### Changed
+- `src/types.ts` exports a shared `AnalyzePdfInputShape` consumed by both the MCP tool registration and the HTTP `/analyze` handler, eliminating the duplicated inline schema definitions.
+
 ## [1.2.3] - 2026-04-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/pdf-analyzer",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "MCP server for analyzing PDF documents using AI (Google Gemini, Anthropic Claude, OpenAI)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Patch release.

### Fixed
- `/analyze` HTTP endpoint validates request bodies against `AnalyzePdfInputSchema` (same schema as the MCP path). Malformed `pdf_source` values now produce a `400` with zod path-aware errors instead of crashing inside `validateLocalPath`. Closes #42.

### Changed
- `AnalyzePdfInputShape` exported from `src/types.ts` is the single source of truth for both transports.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)