### PR TITLE
docs: remove Gemini CLI and VS Code (GitHub Copilot) from supported MCP clients

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ What actually happened.
 
 - OS: [e.g., macOS 14.0, Windows 11, Ubuntu 22.04]
 - Node.js version: [e.g., 20.10.0]
-- MCP Client: [e.g., Claude Code, Claude Desktop, VS Code]
+- MCP Client: [e.g., Claude Code, Claude Desktop]
 
 ## Netlist Format
 

--- a/README.md
+++ b/README.md
@@ -98,33 +98,6 @@ Install [OpenAI Codex](https://developers.openai.com/codex/cli/), then run:
 codex mcp add pdf-analyzer -- pdf-analyzer
 ```
 
-### Gemini CLI
-
-Install [Gemini CLI](https://geminicli.com/docs/get-started/installation/), then run:
-
-```bash
-gemini mcp add --scope user pdf-analyzer pdf-analyzer
-```
-
-### VS Code (GitHub Copilot)
-
-Download [VS Code](https://code.visualstudio.com/)
-
-Add to `.vscode/mcp.json` in your project:
-
-```json
-{
-  "servers": {
-    "pdf-analyzer": {
-      "type": "stdio",
-      "command": "pdf-analyzer"
-    }
-  }
-}
-```
-
-Then enable it in **Configure Tools** (click the tools icon in Copilot chat).
-
 ## Usage
 
 Once connected, ask your AI assistant to analyze any PDF:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,7 +84,7 @@ When the `PORT` environment variable is set (Cloud Run sets this automatically),
 
 ### The `/mcp` Endpoint
 
-Used by MCP-aware clients (Claude Code, VS Code, Gemini CLI). The request body is a JSON-RPC message following the MCP Streamable HTTP specification. The response is an SSE stream.
+Used by MCP-aware clients (Claude Code). The request body is a JSON-RPC message following the MCP Streamable HTTP specification. The response is an SSE stream.
 
 ```bash
 curl -X POST https://your-service.run.app/mcp \


### PR DESCRIPTION
Removes Gemini CLI and VS Code (GitHub Copilot) from the list of supported MCP clients.

- **README.md** — drop the `### Gemini CLI` and `### VS Code (GitHub Copilot)` install sections.
- **docs/architecture.md** — remove VS Code and Gemini CLI from the MCP-aware client list.
- **.github/ISSUE_TEMPLATE/bug_report.md** — remove `VS Code` from the MCP-client example list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)