### PR TITLE
docs: name all five providers, and the flagship we actually default to

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The **PDF Analyzer MCP Server** gives AI agents the ability to read and
 analyze PDF documents, enabling document Q&A through natural conversations.
 
-Supports multiple LLM providers: **Google Gemini**, **Anthropic Claude**, and **OpenAI**. Choose your preferred provider and model during setup.
+Supports multiple LLM providers: **Google Gemini**, **Anthropic Claude**, and **OpenAI** on their direct APIs, plus **Google Vertex AI** and **Anthropic on Vertex AI** for service-account auth. Choose your preferred provider and model during setup.
 
 ## Native Install (Recommended)
 
@@ -73,8 +73,10 @@ You'll be prompted to choose from:
 | Provider | Fast Model | Flagship Model | Get API Key |
 |----------|-----------|----------------|-------------|
 | Google Gemini | Gemini 3 Flash | Gemini 3.1 Pro | [Google AI Studio](https://aistudio.google.com/apikey) |
-| Anthropic Claude | Claude Sonnet 4.6 | Claude Opus 4.6 | [Anthropic Console](https://console.anthropic.com/settings/keys) |
+| Anthropic Claude | Claude Sonnet 4.6 | Claude Opus 4.7 | [Anthropic Console](https://console.anthropic.com/settings/keys) |
 | OpenAI GPT | GPT-5.4 Mini | GPT-5.4 | [OpenAI Platform](https://platform.openai.com/api-keys) |
+
+Claude Opus 4.6 is offered alongside 4.7 as the previous flagship. The Vertex AI providers offer the same Gemini and Claude models, and authenticate with a service account JSON key file instead of an API key.
 
 You can re-run `--setup` at any time to switch providers or models.
 
@@ -119,7 +121,15 @@ The server accepts:
 | Linux (ARM64) | `pdf-analyzer-linux-arm64` |
 | Windows (x64) | `pdf-analyzer-windows-x64.exe` |
 
+## Running as a hosted server
+
+Setting `PORT` starts the server over Streamable HTTP instead of stdio, serving MCP at `/mcp`, a direct `POST /analyze` REST endpoint, and `GET /health`.
+
+See [deploy/README.md](deploy/README.md) for deploying it to Cloud Run, including the provider and auth matrix, the IAM roles each provider needs, and how to reach the private service.
+
 ## Documentation
+
+See [docs/architecture.md](docs/architecture.md) for how the server is put together.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,8 +10,8 @@ Both modes expose the same `analyze_pdf` tool. The difference is how the client 
 ┌─────────────┐    stdin/stdout    ┌────────────────┐     API call     ┌─────────────┐
 │  MCP Client  │ ◄──────────────► │  pdf-analyzer   │ ──────────────► │  LLM Provider │
 │  (e.g. Claude│                   │  (child process)│                  │  (Gemini, etc)│
-│   Code, VS   │                   │                 │                  │               │
-│   Code, etc) │                   │  reads local    │                  └───────────────┘
+│   Code,      │                   │                 │                  │               │
+│   Codex)     │                   │  reads local    │                  └───────────────┘
 └──────────────┘                   │  files directly │
                                    └─────────────────┘
 ```
@@ -23,7 +23,7 @@ The MCP client spawns `pdf-analyzer` as a child process. Communication happens o
 1. The client starts `pdf-analyzer` as a subprocess
 2. Client sends a JSON-RPC request over stdin (e.g., `tools/call` with `analyze_pdf`)
 3. The server reads the PDF from disk or fetches it from a URL
-4. The server sends the PDF to the configured LLM provider (Google Gemini, Anthropic Claude, or OpenAI) using the provider's API key stored in the OS credential store
+4. The server sends the PDF to the configured LLM provider (Google Gemini, Anthropic Claude, or OpenAI) using the provider's API key stored in the OS credential store. The Vertex AI providers authenticate with a service account JSON key file instead
 5. The server writes the JSON-RPC response to stdout
 
 **PDF sources supported:**

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -41,7 +41,8 @@ export const printHelp = (): void => {
 ${BINARY_NAME} v${VERSION}
 
 MCP server for analyzing PDF documents using AI.
-Supports Google Gemini, Google Vertex AI, Anthropic Claude, and OpenAI.
+Supports Google Gemini, Anthropic Claude, and OpenAI, plus Google Vertex AI
+and Anthropic on Vertex AI.
 
 USAGE:
   ${BINARY_NAME} [OPTIONS]


### PR DESCRIPTION
Third repo in the same pass, after IntelligentElectron/universal-netlist#122 and IntelligentElectron/pcb-lens#59.

## Two providers were missing from every description

`src/providers/registry.ts` exposes five providers. The README named three, and `--help` named four (it had Google's Vertex but not Anthropic's):

| | README | `--help` | Registry |
|---|---|---|---|
| `google` | ✅ | ✅ | ✅ |
| `anthropic` | ✅ | ✅ | ✅ |
| `openai` | ✅ | ✅ | ✅ |
| `google-vertex` | ❌ | ✅ | ✅ |
| `anthropic-vertex` | ❌ | ❌ | ✅ |

## The advertised flagship was the previous one

`src/providers/anthropic.ts` sets `DEFAULT_MODEL = "claude-opus-4-7"` and labels `claude-opus-4-6` as `"Previous flagship"`. The setup table advertised 4.6 as the flagship, so the README recommended a model the tool itself has moved on from. 4.6 is still selectable, and is now described as such.

## HTTP mode was undocumented on the front page

`PORT` starts Streamable HTTP instead of stdio, serving `/mcp`, `POST /analyze`, and `GET /health`, and `deploy/` carries a full Cloud Run guide with a provider/auth matrix. None of it was reachable from the README, nor was `docs/architecture.md`. Both are linked now.

## A leftover from #45

#45 removed VS Code (GitHub Copilot) from the supported clients, but the stdio diagram in `docs/architecture.md` still offered it as an example. The string survived because ASCII box art splits it across two lines (`│   Code, VS   │` / `│   Code, etc) │`), so a grep for "VS Code" does not match it.

## Testing

`npm test` is green (98 passed, 2 skipped). Note that `keychain.test.ts` and `transports/http.test.ts` fail under a restrictive sandbox, since they need keychain access and a loopback socket; they pass normally and fail identically on an unmodified tree.

## Changelog

The README, `--help`, and architecture doc describe all five providers, including Anthropic on Vertex AI, which no description mentioned. The Anthropic flagship is listed as Claude Opus 4.7, the model the server defaults to, rather than 4.6. The README now documents the `PORT`-triggered HTTP mode and links the Cloud Run deployment guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)